### PR TITLE
handle time-zone change in weekly-view #163 

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/calendar/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/activities/MainActivity.kt
@@ -418,7 +418,7 @@ class MainActivity : SimpleActivity(), NavigationListener {
     private fun getWeekTimestamps(targetWeekTS: Int): List<Int> {
         val weekTSs = ArrayList<Int>(PREFILLED_WEEKS)
         for (i in -PREFILLED_WEEKS / 2..PREFILLED_WEEKS / 2) {
-            weekTSs.add(targetWeekTS + i * WEEK_SECONDS)
+            weekTSs.add(Formatter.getDateTimeFromTS(targetWeekTS).plusWeeks(i).seconds())
         }
         return weekTSs
     }


### PR DESCRIPTION
fix missing / repeated days in weekly views problem #163 .
problem : time zone change make the weektimestamp move to next/previous day .