### PR TITLE
Use local country names for the list of holidays

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/calendar/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/activities/MainActivity.kt
@@ -571,7 +571,7 @@ class MainActivity : SimpleActivity(), NavigationListener {
             put("Italia", "italy.ics")
             put("Magyarország", "hungary.ics")
             put("Nederland", "netherlands.ics")
-            put("Nihon", "japan.ics")
+            put("日本", "japan.ics")
             put("Norge", "norway.ics")
             put("Pākistān", "pakistan.ics")
             put("Polska", "poland.ics")

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/activities/MainActivity.kt
@@ -576,7 +576,7 @@ class MainActivity : SimpleActivity(), NavigationListener {
             put("Pākistān", "pakistan.ics")
             put("Polska", "poland.ics")
             put("Portugal", "portugal.ics")
-            put("Rossiya", "russia.ics")
+            put("Россия", "russia.ics")
             put("Schweiz", "switzerland.ics")
             put("Slovenija", "slovenia.ics")
             put("Slovensko", "slovakia.ics")


### PR DESCRIPTION
The list already uses local names in local script for some countries, but not for all. Two names stood out particularly: Rossiya and Nihon. I can say that the former didn't look right at all, and the latter looked like it also needed improving, so I went ahead and changed both of them to be in local script.

https://en.wikipedia.org/wiki/Russia
https://en.wikipedia.org/wiki/Japan

Now, sometimes people want to add holidays of foreign countries, but don't understand their script, and this PR obviously makes this problem somewhat worse, but if that's important, then the whole list needs be made translatable as a full-fledged part of UI (or maybe Android already has translated country names somewhere).