### PR TITLE
Content description

### DIFF
--- a/app/src/main/res/layout/activity_event.xml
+++ b/app/src/main/res/layout/activity_event.xml
@@ -51,6 +51,7 @@
             android:layout_below="@+id/event_description"
             android:layout_marginBottom="@dimen/normal_margin"
             android:layout_marginTop="@dimen/activity_margin"
+            android:importantForAccessibility="no"
             android:background="@color/darker_divider"/>
 
         <ImageView
@@ -146,6 +147,7 @@
             android:layout_below="@+id/event_end_date"
             android:layout_marginBottom="@dimen/medium_margin"
             android:layout_marginTop="@dimen/medium_margin"
+            android:importantForAccessibility="no"
             android:background="@color/darker_divider"/>
 
         <ImageView
@@ -212,6 +214,7 @@
             android:layout_below="@+id/event_reminder_3"
             android:layout_marginBottom="@dimen/medium_margin"
             android:layout_marginTop="@dimen/medium_margin"
+            android:importantForAccessibility="no"
             android:background="@color/darker_divider"/>
 
         <ImageView
@@ -319,6 +322,7 @@
             android:layout_below="@+id/event_repetition_limit_holder"
             android:layout_marginBottom="@dimen/medium_margin"
             android:layout_marginTop="@dimen/medium_margin"
+            android:importantForAccessibility="no"
             android:background="@color/darker_divider"/>
 
         <ImageView

--- a/app/src/main/res/layout/activity_event.xml
+++ b/app/src/main/res/layout/activity_event.xml
@@ -2,6 +2,7 @@
 <ScrollView
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/event_scrollview"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
@@ -98,7 +99,7 @@
             android:paddingEnd="@dimen/activity_margin"
             android:paddingRight="@dimen/activity_margin"
             android:paddingTop="@dimen/activity_margin"
-            android:text="January 1 1970"
+            tools:text="January 1 1970"
             android:textSize="@dimen/day_text_size"/>
 
         <com.simplemobiletools.commons.views.MyTextView
@@ -110,7 +111,7 @@
             android:layout_below="@+id/event_time_image"
             android:background="?attr/selectableItemBackground"
             android:padding="@dimen/activity_margin"
-            android:text="00:00"
+            tools:text="00:00"
             android:textSize="@dimen/day_text_size"/>
 
         <com.simplemobiletools.commons.views.MyTextView
@@ -125,7 +126,7 @@
             android:paddingEnd="@dimen/activity_margin"
             android:paddingRight="@dimen/activity_margin"
             android:paddingTop="@dimen/activity_margin"
-            android:text="January 1 1970"
+            tools:text="January 1 1970"
             android:textSize="@dimen/day_text_size"/>
 
         <com.simplemobiletools.commons.views.MyTextView
@@ -137,7 +138,7 @@
             android:layout_below="@+id/event_start_time"
             android:background="?attr/selectableItemBackground"
             android:padding="@dimen/activity_margin"
-            android:text="00:00"
+            tools:text="00:00"
             android:textSize="@dimen/day_text_size"/>
 
         <ImageView

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -23,6 +23,7 @@
                 android:id="@+id/week_view_hours_divider"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
+                android:importantForAccessibility="no"
                 android:layout_alignRight="@+id/week_view_hours_scrollview"
                 android:background="@drawable/stroke_bottom_right"/>
 

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -256,6 +256,7 @@
 
         <ImageView
             android:id="@+id/weekly_view_divider"
+            android:importantForAccessibility="no"
             android:layout_width="match_parent"
             android:layout_height="1px"
             android:background="@color/divider_strong"/>
@@ -346,6 +347,7 @@
             android:id="@+id/monthly_view_divider"
             android:layout_width="match_parent"
             android:layout_height="1px"
+            android:importantForAccessibility="no"
             android:background="@color/divider_strong"/>
 
         <com.simplemobiletools.commons.views.MyTextView
@@ -385,6 +387,7 @@
             android:id="@+id/events_list_view_divider"
             android:layout_width="match_parent"
             android:layout_height="1px"
+            android:importantForAccessibility="no"
             android:background="@color/divider_strong"/>
 
         <com.simplemobiletools.commons.views.MyTextView
@@ -438,6 +441,7 @@
             android:id="@+id/widgets_divider"
             android:layout_width="match_parent"
             android:layout_height="1px"
+            android:importantForAccessibility="no"
             android:background="@color/divider_strong"/>
 
         <com.simplemobiletools.commons.views.MyTextView

--- a/app/src/main/res/layout/dialog_export_events.xml
+++ b/app/src/main/res/layout/dialog_export_events.xml
@@ -65,6 +65,7 @@
 
             <ImageView
                 android:id="@+id/export_events_divider"
+                android:importantForAccessibility="no"
                 android:layout_width="match_parent"
                 android:layout_height="1px"
                 android:layout_marginBottom="@dimen/medium_margin"

--- a/app/src/main/res/layout/dialog_repeat_limit_type_picker.xml
+++ b/app/src/main/res/layout/dialog_repeat_limit_type_picker.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/dialog_repeat_type_picker_holder"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
@@ -25,7 +26,7 @@
             android:layout_marginStart="@dimen/repeat_type_margin_start"
             android:paddingBottom="@dimen/normal_margin"
             android:paddingTop="@dimen/medium_margin"
-            android:text="January 1 1970"/>
+            tools:text="January 1 1970"/>
 
         <com.simplemobiletools.commons.views.MyCompatRadioButton
             android:id="@+id/repeat_type_x_times"

--- a/app/src/main/res/layout/event_item_day_view.xml
+++ b/app/src/main/res/layout/event_item_day_view.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/event_item_frame"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -18,7 +19,7 @@
             android:id="@+id/event_item_start"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="13:00"
+            tools:text="13:00"
             android:textSize="@dimen/day_text_size"/>
 
         <com.simplemobiletools.commons.views.MyTextView
@@ -26,7 +27,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_below="@+id/event_item_start"
-            android:text="15:00"
+            tools:text="15:00"
             android:textSize="@dimen/day_text_size"/>
 
         <com.simplemobiletools.commons.views.MyTextView
@@ -38,7 +39,7 @@
             android:ellipsize="end"
             android:maxLines="1"
             android:paddingRight="@dimen/activity_margin"
-            android:text="Event title"
+            tools:text="Event title"
             android:textSize="@dimen/day_text_size"/>
 
         <com.simplemobiletools.commons.views.MyTextView
@@ -52,7 +53,7 @@
             android:ellipsize="end"
             android:maxLines="1"
             android:paddingRight="@dimen/activity_margin"
-            android:text="Event description"
+            tools:text="Event description"
             android:textSize="@dimen/day_text_size"/>
 
     </RelativeLayout>

--- a/app/src/main/res/layout/event_list_item.xml
+++ b/app/src/main/res/layout/event_list_item.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/event_item_frame"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -21,7 +22,7 @@
             android:id="@+id/event_item_start"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="13:00"
+            tools:text="13:00"
             android:textSize="@dimen/day_text_size"/>
 
         <com.simplemobiletools.commons.views.MyTextView
@@ -29,7 +30,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_below="@+id/event_item_start"
-            android:text="15:00"
+            tools:text="15:00"
             android:textSize="@dimen/day_text_size"/>
 
         <com.simplemobiletools.commons.views.MyTextView
@@ -40,7 +41,7 @@
             android:layout_toRightOf="@+id/event_item_start"
             android:ellipsize="end"
             android:maxLines="1"
-            android:text="Event title"
+            tools:text="Event title"
             android:textSize="@dimen/day_text_size"/>
 
         <com.simplemobiletools.commons.views.MyTextView
@@ -53,7 +54,7 @@
             android:alpha=".4"
             android:ellipsize="end"
             android:maxLines="1"
-            android:text="Event description"
+            tools:text="Event description"
             android:textSize="@dimen/day_text_size"/>
 
     </RelativeLayout>

--- a/app/src/main/res/layout/event_list_item_widget.xml
+++ b/app/src/main/res/layout/event_list_item_widget.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/event_item_holder"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
@@ -10,7 +11,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginLeft="@dimen/activity_margin"
-        android:text="13:00"
+        tools:text="13:00"
         android:textSize="@dimen/day_text_size"/>
 
     <TextView
@@ -19,7 +20,7 @@
         android:layout_height="wrap_content"
         android:layout_below="@+id/event_item_start"
         android:layout_marginLeft="@dimen/activity_margin"
-        android:text="15:00"
+        tools:text="15:00"
         android:textSize="@dimen/day_text_size"/>
 
     <TextView
@@ -31,7 +32,7 @@
         android:ellipsize="end"
         android:maxLines="1"
         android:paddingRight="@dimen/activity_margin"
-        android:text="Event title"
+        tools:text="Event title"
         android:textSize="@dimen/day_text_size"/>
 
     <TextView
@@ -45,7 +46,7 @@
         android:ellipsize="end"
         android:maxLines="1"
         android:paddingRight="@dimen/activity_margin"
-        android:text="Event description"
+        tools:text="Event description"
         android:textSize="@dimen/day_text_size"/>
 
 </RelativeLayout>

--- a/app/src/main/res/layout/first_row.xml
+++ b/app/src/main/res/layout/first_row.xml
@@ -3,6 +3,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_weight="1"
     android:orientation="horizontal">
 
@@ -12,8 +13,9 @@
         android:layout_width="0dp"
         android:layout_height="match_parent"
         android:layout_weight="1"
-        android:text="#"
-        android:visibility="gone"/>
+        tools:text="#"
+        android:visibility="gone"
+        tools:visibility="visible"/>
 
     <com.simplemobiletools.commons.views.MyTextView
         android:id="@+id/label_0"

--- a/app/src/main/res/layout/first_row_widget.xml
+++ b/app/src/main/res/layout/first_row_widget.xml
@@ -3,6 +3,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_weight="1"
     android:orientation="horizontal">
 
@@ -12,8 +13,9 @@
         android:layout_width="0dp"
         android:layout_height="match_parent"
         android:layout_weight="1"
-        android:text="#"
-        android:visibility="gone"/>
+        tools:text="#"
+        android:visibility="gone"
+        tools:visibility="visible"/>
 
     <TextView
         android:id="@+id/label_0"


### PR DESCRIPTION
Hard-coded as they’re always replaced at runtime, so better to have them as `tools:text`