### PR TITLE
Add fdroid buildType so leak canary can be excluded.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,12 +25,16 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             signingConfig signingConfigs.release
         }
+        fdroid {
+            initWith debug
+        }
     }
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
         debug.java.srcDirs += 'src/debug/kotlin'
         release.java.srcDirs += 'src/release/kotlin'
+        fdroid.java.srcDirs += 'src/fdroid/kotlin'
     }
 
     lintOptions {

--- a/app/src/fdroid/kotlin/com/simplemobiletools/calendar/BuildVariantApplication.kt
+++ b/app/src/fdroid/kotlin/com/simplemobiletools/calendar/BuildVariantApplication.kt
@@ -1,0 +1,3 @@
+package com.simplemobiletools.calendar
+
+open class BuildVariantApplication : BaseApp()


### PR DESCRIPTION
I'm not sure if this is 100% complete, but I think it's along the lines of what you're looking for. Switch to having two productFlavors, one for fdroid, one regular. For the fdroid version the debug/release version of `BuildVariantAppliction` is the same and neither includes LeakCanary. For the regular one the debug version includes LeakCanary as before. Nothing else is different between the two productFlavors.