### PR TITLE
german Strings updated

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -159,11 +159,11 @@
     <string name="loop_reminders">Erinnerungen wiederholen bis sie verworfen werden</string>
     <string name="dim_past_events">Vergangene Termine ausgrauen</string>
     <string name="events">Termine</string>
-    <string name="reminder_stream">xAudiodatei für Erinnerung</string>
-    <string name="system_stream">System</string>
-    <string name="alarm_stream">Alarm</string>
-    <string name="notification_stream">xAudiodatei für Benachrichtigung</string>
-    <string name="ring_stream">Ring</string>
+    <string name="reminder_stream">Audio Ausgabekanal für Erinnerungen</string>
+    <string name="system_stream">Medien</string>
+    <string name="alarm_stream">Wecker</string>
+    <string name="notification_stream">Benachrichtigung/string>
+    <string name="ring_stream">Klingelton</string>
 
     <!-- CalDAV sync -->
     <string name="caldav">CalDAV</string>
@@ -205,9 +205,9 @@
     <string name="faq_2_text">Ja, aktiviere \"CalDAV Synchronisierung\" in den Einstellungen und wähle die Kalender aus, die du synchronisieren willst. 
         Jedoch benötigst du eine separate App, die Synchronisierung zwischen Gerät und Servern handhabt. Falls du einen Google Kalender synchronisieren willst, kann die offizielle Kalender-App dies übernehmen.
         Für andere Kalender benötigst du einen Synchronisierungsadapter, wie z. B. DAVdroid.</string>
-    <string name="faq_3_title">I see the visual reminders, but hear no audio. What can I do?</string>
-    <string name="faq_3_text">Not just displaying the actual reminder, but playing the audio is hugely affected by the system too. If you can\'t hear any sound, try going in the app settings,
-        pressing the \"Audio stream used by reminders\" option and changing it to a different value. If it still won\'t work, check your sound settings, if the particular stream isn\'t muted.</string>
+    <string name="faq_3_title">Ich sehe die Erinenrungen, aber ich höre keinen Ton. Was kann ich tun?</string>
+    <string name="faq_3_text">Erinnerungen nicht nur anzeigen, sondern Töne dazu abspielen ist ebenfalls stark vom jeweiligen (Android) System abhängig. Wenn Du keine Töne hörst, versuche in den App Einstellungen,
+        die Option \"Audio Kanal für Erinnerungen\" anzuklicken und eine andere Option auszuwählen. Wenn das immer noch nichts ändert, prüfe Deine Lautstärkeeinstellungen. of der gewählte Kanal nicht auf lautlos steht.</string>
 
     <!-- Strings displayed only on Google Playstore. Optional, but good to have -->
     <!-- Short description has to have less than 80 chars -->

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -207,7 +207,7 @@
         Für andere Kalender benötigst du einen Synchronisierungsadapter, wie z. B. DAVdroid.</string>
     <string name="faq_3_title">Ich sehe die Erinenrungen, aber ich höre keinen Ton. Was kann ich tun?</string>
     <string name="faq_3_text">Erinnerungen nicht nur anzeigen, sondern Töne dazu abspielen ist ebenfalls stark vom jeweiligen (Android) System abhängig. Wenn Du keine Töne hörst, versuche in den App Einstellungen,
-        die Option \"Audio Kanal für Erinnerungen\" anzuklicken und eine andere Option auszuwählen. Wenn das immer noch nichts ändert, prüfe Deine Lautstärkeeinstellungen. of der gewählte Kanal nicht auf lautlos steht.</string>
+        die Option \"Audio Ausgabekanal für Erinnerungen\" anzuklicken und eine andere Option auszuwählen. Wenn das immer noch nichts ändert, prüfe Deine Lautstärkeeinstellungen. of der gewählte Kanal nicht auf lautlos steht.</string>
 
     <!-- Strings displayed only on Google Playstore. Optional, but good to have -->
     <!-- Short description has to have less than 80 chars -->

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -44,7 +44,7 @@
     <string name="event_is_repeatable">Termin ist wiederholbar</string>
     <string name="selection_contains_repetition">Die Auswahl enthält Ereignisse mit Wiederholungen</string>
     <string name="delete_one_only">Lösche nur die ausgewählte Wiederholung</string>
-    <string name="delete_future_occurrences">Delete this and all future occurrences</string>
+    <string name="delete_future_occurrences">Lösche diese und zukünftige Wiederholungen</string>
     <string name="delete_all_occurrences">Lösche alle Wiederholungen</string>
     <string name="update_one_only">Ändere nur die ausgewählte Wiederholung</string>
     <string name="update_all_occurrences">Ändere alle Wiederholungen</string>
@@ -159,10 +159,10 @@
     <string name="loop_reminders">Erinnerungen wiederholen bis sie verworfen werden</string>
     <string name="dim_past_events">Vergangene Termine ausgrauen</string>
     <string name="events">Termine</string>
-    <string name="reminder_stream">Audio stream used by reminders</string>
+    <string name="reminder_stream">xAudiodatei für Erinnerung</string>
     <string name="system_stream">System</string>
     <string name="alarm_stream">Alarm</string>
-    <string name="notification_stream">Notification</string>
+    <string name="notification_stream">xAudiodatei für Benachrichtigung</string>
     <string name="ring_stream">Ring</string>
 
     <!-- CalDAV sync -->


### PR DESCRIPTION
Hi Tibor,

tried to find all (new) German strings, currently in English. All I've found translated in this patch/pull request.
"reminder audio streams" somewhat hard to translate, I've followed my Android 6.0 German settings names  at "settings" / "Sound&notification" / "Volumes". From an end user perspective, audio stream "system" is called "media volume", also in English. Changed FAQ also.

CAN'T find keys for:

- "Purchase Simple Thank You"
- "Snooze ..." (Not sure if this might be even "snooze" in German, as most are used to this English wird, German verb is "schlummern")
- "Customize widget colors"

They seems to be inherited. Or maybe (e.g. settings_snooze_time_label), not ready to be localized right now?


