### PR TITLE
Added setting to let user choose his favorite default view

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/calendar/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/activities/MainActivity.kt
@@ -251,12 +251,12 @@ class MainActivity : SimpleActivity(), RefreshRecyclerViewListener {
 
     private fun checkOpenIntents(): Boolean {
         val dayCodeToOpen = intent.getStringExtra(DAY_CODE) ?: ""
-        val openMonth = intent.getBooleanExtra(OPEN_MONTH, false)
-        intent.removeExtra(OPEN_MONTH)
+        val viewToOpen = intent.getIntExtra(VIEW_TO_OPEN, DAILY_VIEW)
+        intent.removeExtra(VIEW_TO_OPEN)
         intent.removeExtra(DAY_CODE)
         if (dayCodeToOpen.isNotEmpty()) {
             calendar_fab.beVisible()
-            config.storedView = if (openMonth) MONTHLY_VIEW else DAILY_VIEW
+            if (viewToOpen != LAST_VIEW) {config.storedView = viewToOpen}
             updateViewPager(dayCodeToOpen)
             return true
         }

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/activities/SettingsActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/activities/SettingsActivity.kt
@@ -67,6 +67,7 @@ class SettingsActivity : SimpleActivity() {
         setupDisplayPastEvents()
         setupFontSize()
         setupCustomizeWidgetColors()
+        setupDefaultView()
         setupDimEvents()
         updateTextColors(settings_holder)
         checkPrimaryColor()
@@ -500,6 +501,35 @@ class SettingsActivity : SimpleActivity() {
             }
         }
     }
+
+    private fun setupDefaultView() {
+        settings_default_view.text = getDefaultViewText()
+        settings_default_view_holder.setOnClickListener {
+            val items = arrayListOf(
+                    RadioItem(DAILY_VIEW, res.getString(R.string.daily_view)),
+                    RadioItem(WEEKLY_VIEW, res.getString(R.string.weekly_view)),
+                    RadioItem(MONTHLY_VIEW, res.getString(R.string.monthly_view)),
+                    RadioItem(YEARLY_VIEW, res.getString(R.string.yearly_view)),
+                    RadioItem(EVENTS_LIST_VIEW, res.getString(R.string.simple_event_list)),
+                    RadioItem(LAST_VIEW, res.getString(R.string.last_view)))
+
+            RadioGroupDialog(this@SettingsActivity, items, config.defaultView) {
+                config.defaultView = it as Int
+                settings_default_view.text = getDefaultViewText()
+                updateWidgets()
+                updateListWidget()
+            }
+        }
+    }
+
+    private fun getDefaultViewText() = getString(when (config.defaultView) {
+        DAILY_VIEW -> R.string.daily_view
+        WEEKLY_VIEW -> R.string.weekly_view
+        MONTHLY_VIEW -> R.string.monthly_view
+        YEARLY_VIEW -> R.string.yearly_view
+        EVENTS_LIST_VIEW -> R.string.simple_event_list
+        else -> R.string.last_view
+    })
 
     private fun setupDimEvents() {
         settings_dim_past_events.isChecked = config.dimPastEvents

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/activities/SplashActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/activities/SplashActivity.kt
@@ -1,10 +1,7 @@
 package com.simplemobiletools.calendar.activities
 
 import android.content.Intent
-import com.simplemobiletools.calendar.helpers.DAY_CODE
-import com.simplemobiletools.calendar.helpers.EVENT_ID
-import com.simplemobiletools.calendar.helpers.EVENT_OCCURRENCE_TS
-import com.simplemobiletools.calendar.helpers.OPEN_MONTH
+import com.simplemobiletools.calendar.helpers.*
 import com.simplemobiletools.commons.activities.BaseSplashActivity
 
 class SplashActivity : BaseSplashActivity() {
@@ -12,7 +9,7 @@ class SplashActivity : BaseSplashActivity() {
         when {
             intent.extras?.containsKey(DAY_CODE) == true -> Intent(this, MainActivity::class.java).apply {
                 putExtra(DAY_CODE, intent.getStringExtra(DAY_CODE))
-                putExtra(OPEN_MONTH, intent.getBooleanExtra(OPEN_MONTH, false))
+                putExtra(VIEW_TO_OPEN, intent.getIntExtra(VIEW_TO_OPEN, LAST_VIEW))
                 startActivity(this)
             }
             intent.extras?.containsKey(EVENT_ID) == true -> Intent(this, MainActivity::class.java).apply {

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/helpers/Config.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/helpers/Config.kt
@@ -76,6 +76,10 @@ class Config(context: Context) : BaseConfig(context) {
         get() = prefs.getInt(FONT_SIZE, FONT_SIZE_MEDIUM)
         set(size) = prefs.edit().putInt(FONT_SIZE, size).apply()
 
+    var defaultView: Int
+        get() = prefs.getInt(DEFAULT_VIEW, DAILY_VIEW)
+        set(size) = prefs.edit().putInt(DEFAULT_VIEW, size).apply()
+
     var caldavSync: Boolean
         get() = prefs.getBoolean(CALDAV_SYNC, false)
         set(caldavSync) {

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/helpers/Constants.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/helpers/Constants.kt
@@ -14,13 +14,14 @@ const val WEEK_START_TIMESTAMP = "week_start_timestamp"
 const val NEW_EVENT_SET_HOUR_DURATION = "new_event_set_hour_duration"
 const val WEEK_START_DATE_TIME = "week_start_date_time"
 const val CALDAV = "Caldav"
-const val OPEN_MONTH = "open_month"
+const val VIEW_TO_OPEN = "view_to_open"
 
 const val MONTHLY_VIEW = 1
 const val YEARLY_VIEW = 2
 const val EVENTS_LIST_VIEW = 3
 const val WEEKLY_VIEW = 4
 const val DAILY_VIEW = 5
+const val LAST_VIEW = 6
 
 const val REMINDER_OFF = -1
 
@@ -46,6 +47,7 @@ const val LAST_EVENT_REMINDER_MINUTES_2 = "reminder_minutes_2"
 const val LAST_EVENT_REMINDER_MINUTES_3 = "reminder_minutes_3"
 const val DISPLAY_EVENT_TYPES = "display_event_types"
 const val FONT_SIZE = "font_size"
+const val DEFAULT_VIEW = "default_view"
 const val CALDAV_SYNC = "caldav_sync"
 const val CALDAV_SYNCED_CALENDAR_IDS = "caldav_synced_calendar_ids"
 const val LAST_USED_CALDAV_CALENDAR = "last_used_caldav_calendar"

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/helpers/MyWidgetListProvider.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/helpers/MyWidgetListProvider.kt
@@ -18,7 +18,7 @@ import org.joda.time.DateTime
 
 class MyWidgetListProvider : AppWidgetProvider() {
     private val NEW_EVENT = "new_event"
-    private val LAUNCH_TODAY = "launch_today"
+    private val LAUNCH_CAL = "launch_cal"
 
     override fun onUpdate(context: Context, appWidgetManager: AppWidgetManager, appWidgetIds: IntArray) {
         performUpdate(context)
@@ -44,7 +44,7 @@ class MyWidgetListProvider : AppWidgetProvider() {
 
             views.setImageViewBitmap(R.id.widget_event_new_event, context.resources.getColoredBitmap(R.drawable.ic_plus, textColor))
             setupIntent(context, views, NEW_EVENT, R.id.widget_event_new_event)
-            setupIntent(context, views, LAUNCH_TODAY, R.id.widget_event_list_today)
+            setupIntent(context, views, LAUNCH_CAL, R.id.widget_event_list_today)
 
             Intent(context, WidgetService::class.java).apply {
                 data = Uri.parse(this.toUri(Intent.URI_INTENT_SCHEME))
@@ -74,14 +74,15 @@ class MyWidgetListProvider : AppWidgetProvider() {
     override fun onReceive(context: Context, intent: Intent) {
         when (intent.action) {
             NEW_EVENT -> context.launchNewEventIntent()
-            LAUNCH_TODAY -> launchDayActivity(context)
+            LAUNCH_CAL -> launchCalenderInDefaultView(context)
             else -> super.onReceive(context, intent)
         }
     }
 
-    private fun launchDayActivity(context: Context) {
+    private fun launchCalenderInDefaultView(context: Context) {
         (context.getLaunchIntent() ?: Intent(context, SplashActivity::class.java)).apply {
             putExtra(DAY_CODE, Formatter.getDayCodeFromDateTime(DateTime()))
+            putExtra(VIEW_TO_OPEN, context.config.defaultView)
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
             context.startActivity(this)
         }

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/helpers/MyWidgetMonthlyProvider.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/helpers/MyWidgetMonthlyProvider.kt
@@ -49,7 +49,7 @@ class MyWidgetMonthlyProvider : AppWidgetProvider() {
     private fun setupAppOpenIntent(context: Context, views: RemoteViews, id: Int, dayCode: String) {
         (context.getLaunchIntent() ?: Intent(context, SplashActivity::class.java)).apply {
             putExtra(DAY_CODE, dayCode)
-            putExtra(OPEN_MONTH, true)
+            putExtra(VIEW_TO_OPEN, MONTHLY_VIEW)
             val pendingIntent = PendingIntent.getActivity(context, Integer.parseInt(dayCode.substring(0, 6)), this, 0)
             views.setOnClickPendingIntent(id, pendingIntent)
         }

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -849,6 +849,40 @@
 
         </RelativeLayout>
 
+        <RelativeLayout
+            android:id="@+id/settings_default_view_holder"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="?attr/selectableItemBackground"
+            android:paddingBottom="@dimen/activity_margin"
+            android:paddingLeft="@dimen/normal_margin"
+            android:paddingRight="@dimen/normal_margin"
+            android:paddingTop="@dimen/activity_margin">
+
+            <com.simplemobiletools.commons.views.MyTextView
+                android:id="@+id/settings_default_view_label"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_centerVertical="true"
+                android:layout_toLeftOf="@+id/settings_default_view"
+                android:layout_toStartOf="@+id/settings_default_view"
+                android:paddingLeft="@dimen/medium_margin"
+                android:paddingRight="@dimen/medium_margin"
+                android:text="@string/default_view"/>
+
+            <com.simplemobiletools.commons.views.MyTextView
+                android:id="@+id/settings_default_view"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentEnd="true"
+                android:layout_alignParentRight="true"
+                android:layout_marginEnd="@dimen/small_margin"
+                android:layout_marginRight="@dimen/small_margin"
+                android:background="@null"
+                android:clickable="false"/>
+
+        </RelativeLayout>
+
         <View
             android:id="@+id/events_divider"
             android:layout_width="match_parent"

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -168,6 +168,8 @@
     <string name="default_reminder_1">Default reminder 1</string>
     <string name="default_reminder_2">Default reminder 2</string>
     <string name="default_reminder_3">Default reminder 3</string>
+    <string name="default_view">Default view</string>
+    <string name="last_view">Last view</string>
 
     <!-- CalDAV sync -->
     <string name="caldav">CalDAV</string>

--- a/app/src/main/res/values-br/strings.xml
+++ b/app/src/main/res/values-br/strings.xml
@@ -168,6 +168,8 @@
     <string name="default_reminder_1">Default reminder 1</string>
     <string name="default_reminder_2">Default reminder 2</string>
     <string name="default_reminder_3">Default reminder 3</string>
+    <string name="default_view">Default view</string>
+    <string name="last_view">Last view</string>
 
     <!-- CalDAV sync -->
     <string name="caldav">CalDAV</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -168,6 +168,8 @@
     <string name="default_reminder_1">Výchozí připomenutí 1</string>
     <string name="default_reminder_2">Výchozí připomenutí 2</string>
     <string name="default_reminder_3">Výchozí připomenutí 3</string>
+    <string name="default_view">Default view</string>
+    <string name="last_view">Last view</string>
 
     <!-- CalDAV sync -->
     <string name="caldav">CalDAV</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -168,6 +168,8 @@
     <string name="default_reminder_1">Påmindelse 1</string>
     <string name="default_reminder_2">Påmindelse 2</string>
     <string name="default_reminder_3">Påmindelse 3</string>
+    <string name="default_view">Default view</string>
+    <string name="last_view">Last view</string>
 
     <!-- CalDAV sync -->
     <string name="caldav">CalDAV</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -168,6 +168,8 @@
     <string name="default_reminder_1">Standarderinnerung 1</string>
     <string name="default_reminder_2">Standarderinnerung 2</string>
     <string name="default_reminder_3">Standarderinnerung 3</string>
+    <string name="last_view">Letzte Ansicht</string>
+    <string name="default_view">Standardansicht</string>
 
     <!-- CalDAV sync -->
     <string name="caldav">CalDAV</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -168,6 +168,8 @@
     <string name="default_reminder_1">Default reminder 1</string>
     <string name="default_reminder_2">Default reminder 2</string>
     <string name="default_reminder_3">Default reminder 3</string>
+    <string name="default_view">Default view</string>
+    <string name="last_view">Last view</string>
 
     <!-- CalDAV sync -->
     <string name="caldav">CalDAV</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -168,6 +168,8 @@
     <string name="default_reminder_1">Default reminder 1</string>
     <string name="default_reminder_2">Default reminder 2</string>
     <string name="default_reminder_3">Default reminder 3</string>
+    <string name="default_view">Default view</string>
+    <string name="last_view">Last view</string>
 
     <!-- CalDAV sync -->
     <string name="caldav">CalDAV</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -168,6 +168,8 @@
     <string name="default_reminder_1">Default reminder 1</string>
     <string name="default_reminder_2">Default reminder 2</string>
     <string name="default_reminder_3">Default reminder 3</string>
+    <string name="default_view">Default view</string>
+    <string name="last_view">Last view</string>
 
     <!-- CalDAV sync -->
     <string name="caldav">CalDAV</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -168,6 +168,8 @@
     <string name="default_reminder_1">Default reminder 1</string>
     <string name="default_reminder_2">Default reminder 2</string>
     <string name="default_reminder_3">Default reminder 3</string>
+    <string name="default_view">Default view</string>
+    <string name="last_view">Last view</string>
 
     <!-- CalDAV sync -->
     <string name="caldav">CalDAV</string>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -169,6 +169,8 @@
     <string name="default_reminder_1">Default reminder 1</string>
     <string name="default_reminder_2">Default reminder 2</string>
     <string name="default_reminder_3">Default reminder 3</string>
+    <string name="default_view">Default view</string>
+    <string name="last_view">Last view</string>
 
     <!-- CalDAV sync -->
     <string name="caldav">CalDAV</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -168,6 +168,8 @@
     <string name="default_reminder_1">Default reminder 1</string>
     <string name="default_reminder_2">Default reminder 2</string>
     <string name="default_reminder_3">Default reminder 3</string>
+    <string name="default_view">Default view</string>
+    <string name="last_view">Last view</string>
 
     <!-- CalDAV sync -->
     <string name="caldav">CalDAV</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -168,6 +168,8 @@
     <string name="default_reminder_1">Default reminder 1</string>
     <string name="default_reminder_2">Default reminder 2</string>
     <string name="default_reminder_3">Default reminder 3</string>
+    <string name="default_view">Default view</string>
+    <string name="last_view">Last view</string>
 
     <!-- CalDAV sync -->
     <string name="caldav">CalDAV</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -168,6 +168,8 @@
     <string name="default_reminder_1">Promemoria predefinito 1</string>
     <string name="default_reminder_2">Promemoria predefinito 2</string>
     <string name="default_reminder_3">Promemoria predefinito 3</string>
+    <string name="default_view">Default view</string>
+    <string name="last_view">Last view</string>
 
     <!-- CalDAV sync -->
     <string name="caldav">CalDAV</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -169,6 +169,8 @@
     <string name="default_reminder_1">Default reminder 1</string>
     <string name="default_reminder_2">Default reminder 2</string>
     <string name="default_reminder_3">Default reminder 3</string>
+    <string name="default_view">Default view</string>
+    <string name="last_view">Last view</string>
 
     <!-- CalDAV sync -->
     <string name="caldav">CalDAV</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -168,6 +168,8 @@
     <string name="default_reminder_1">Default reminder 1</string>
     <string name="default_reminder_2">Default reminder 2</string>
     <string name="default_reminder_3">Default reminder 3</string>
+    <string name="default_view">Default view</string>
+    <string name="last_view">Last view</string>
 
     <!-- CalDAV sync -->
     <string name="caldav">CalDAV</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -168,6 +168,8 @@
     <string name="default_reminder_1">Default reminder 1</string>
     <string name="default_reminder_2">Default reminder 2</string>
     <string name="default_reminder_3">Default reminder 3</string>
+    <string name="default_view">Default view</string>
+    <string name="last_view">Last view</string>
 
     <!-- CalDAV sync -->
     <string name="caldav">CalDAV</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -168,6 +168,8 @@
     <string name="default_reminder_1">Default reminder 1</string>
     <string name="default_reminder_2">Default reminder 2</string>
     <string name="default_reminder_3">Default reminder 3</string>
+    <string name="default_view">Default view</string>
+    <string name="last_view">Last view</string>
 
     <!-- CalDAV sync -->
     <string name="caldav">CalDAV</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -168,6 +168,8 @@
     <string name="default_reminder_1">Default reminder 1</string>
     <string name="default_reminder_2">Default reminder 2</string>
     <string name="default_reminder_3">Default reminder 3</string>
+    <string name="default_view">Default view</string>
+    <string name="last_view">Last view</string>
 
     <!-- CalDAV sync -->
     <string name="caldav">CalDAV</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -168,6 +168,8 @@
     <string name="default_reminder_1">Standaardherinnering 1</string>
     <string name="default_reminder_2">Standaardherinnering 2</string>
     <string name="default_reminder_3">Standaardherinnering 3</string>
+    <string name="default_view">Default view</string>
+    <string name="last_view">Last view</string>
 
     <!-- CalDAV sync -->
     <string name="caldav">CalDAV</string>

--- a/app/src/main/res/values-no/strings.xml
+++ b/app/src/main/res/values-no/strings.xml
@@ -168,6 +168,8 @@
     <string name="default_reminder_1">Default reminder 1</string>
     <string name="default_reminder_2">Default reminder 2</string>
     <string name="default_reminder_3">Default reminder 3</string>
+    <string name="default_view">Default view</string>
+    <string name="last_view">Last view</string>
 
     <!-- CalDAV sync -->
     <string name="caldav">CalDAV</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -168,6 +168,8 @@
     <string name="default_reminder_1">Default reminder 1</string>
     <string name="default_reminder_2">Default reminder 2</string>
     <string name="default_reminder_3">Default reminder 3</string>
+    <string name="default_view">Default view</string>
+    <string name="last_view">Last view</string>
 
     <!-- CalDAV sync -->
     <string name="caldav">CalDAV</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -168,6 +168,8 @@
     <string name="default_reminder_1">Default reminder 1</string>
     <string name="default_reminder_2">Default reminder 2</string>
     <string name="default_reminder_3">Default reminder 3</string>
+    <string name="default_view">Default view</string>
+    <string name="last_view">Last view</string>
 
     <!-- CalDAV sync -->
     <string name="caldav">CalDAV</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -168,6 +168,8 @@
     <string name="default_reminder_1">Lembrete 1</string>
     <string name="default_reminder_2">Lembrete 2</string>
     <string name="default_reminder_3">Lembrete 3</string>
+    <string name="default_view">Default view</string>
+    <string name="last_view">Last view</string>
 
     <!-- CalDAV sync -->
     <string name="caldav">CalDAV</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -168,6 +168,8 @@
     <string name="default_reminder_1">Напоминание по умолчанию 1</string>
     <string name="default_reminder_2">Напоминание по умолчанию 2</string>
     <string name="default_reminder_3">Напоминание по умолчанию 3</string>
+    <string name="default_view">Default view</string>
+    <string name="last_view">Last view</string>
 
     <!-- CalDAV sync -->
     <string name="caldav">CalDAV</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -168,6 +168,8 @@
     <string name="default_reminder_1">Predvolená pripomienka 1</string>
     <string name="default_reminder_2">Predvolená pripomienka 2</string>
     <string name="default_reminder_3">Predvolená pripomienka 3</string>
+    <string name="default_view">Default view</string>
+    <string name="last_view">Last view</string>
 
     <!-- CalDAV sync -->
     <string name="caldav">CalDAV</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -168,6 +168,8 @@
     <string name="default_reminder_1">Default reminder 1</string>
     <string name="default_reminder_2">Default reminder 2</string>
     <string name="default_reminder_3">Default reminder 3</string>
+    <string name="default_view">Default view</string>
+    <string name="last_view">Last view</string>
 
     <!-- CalDAV sync -->
     <string name="caldav">CalDAV</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -168,6 +168,8 @@
     <string name="default_reminder_1">Default reminder 1</string>
     <string name="default_reminder_2">Default reminder 2</string>
     <string name="default_reminder_3">Default reminder 3</string>
+    <string name="default_view">Default view</string>
+    <string name="last_view">Last view</string>
 
     <!-- CalDAV sync -->
     <string name="caldav">CalDAV</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -168,6 +168,8 @@
     <string name="default_reminder_1">預設提醒1</string>
     <string name="default_reminder_2">預設提醒2</string>
     <string name="default_reminder_3">預設提醒3</string>
+    <string name="default_view">Default view</string>
+    <string name="last_view">Last view</string>
 
     <!-- CalDAV sync -->
     <string name="caldav">CalDAV</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -168,6 +168,8 @@
     <string name="default_reminder_1">Default reminder 1</string>
     <string name="default_reminder_2">Default reminder 2</string>
     <string name="default_reminder_3">Default reminder 3</string>
+    <string name="default_view">Default view</string>
+    <string name="last_view">Last view</string>
 
     <!-- CalDAV sync -->
     <string name="caldav">CalDAV</string>


### PR DESCRIPTION
- Added "default view" option to settings that allows user to choose which calender view is launched when pressing at the top bar of the events list widget (closes #424 )
- Removed "OPEN_MONTH" extra boolean for selected view and replaced it with more versatile integer to achieve more flexibility
- Added two more strings so far only in english and german