### PR TITLE
Fix End Date of All-Day Events

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/calendar/helpers/CalDAVHandler.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/helpers/CalDAVHandler.kt
@@ -325,7 +325,7 @@ class CalDAVHandler(val context: Context) {
                 put(CalendarContract.Events.RRULE, repeatRule)
             }
 
-            if (event.getIsAllDay() && event.endTS > event.startTS)
+            if (event.getIsAllDay())
                 event.endTS += DAY
 
             if (event.repeatInterval > 0) {


### PR DESCRIPTION
Setting a single day, all-day event, Simple Calendar will set both the
start and end date of the event to the specific date which is incorrect
according to [rfc5545]. The end date is non-inclusive and must hence be
set to the following day:

> The "DTEND" property for a "VEVENT" calendar component specifies the
> non-inclusive end of the event.

This causes weird effects with other calendar apps with e.g. Khal
complaining about the invalid ical or Sogo displaying the event the day
before it should happen.

There is a special exception for one-day, all day events in the
[rfc5545], but that would require no DTEND to be set at all:

> For cases where a "VEVENT" calendar component specifies a "DTSTART"
> property with a DATE value type but no "DTEND" nor "DURATION"
> property, the event's duration is taken to be one day.

Note that this is already correctly handled for multi day events in the
CalDAV export and for all types of events in the .ics export.

[rfc5545] https://tools.ietf.org/html/rfc5545#section-3.6.1