### PR TITLE
Phase One release for Issue #620

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/activities/MainActivity.kt
@@ -85,6 +85,28 @@ class MainActivity : SimpleActivity(), RefreshRecyclerViewListener {
             refreshCalDAVCalendars(false)
         }
 
+        if(hasPermission(PERMISSION_READ_CONTACTS))
+        {
+            Thread{
+                    addContactEvents(true) {
+                        if (it > 0)
+                        {
+                            toast(R.string.birthdays_sync_new)
+                            updateViewPager()
+                        }
+                        else
+                        {
+                            toast(R.string.birthdays_sync_none)
+                        }
+                    }
+                }.start()
+        }
+
+        if(!hasPermission(PERMISSION_READ_CONTACTS))
+        {
+            toast(R.string.birthdays_sync_unable)
+        }
+
         swipe_refresh_layout.setOnRefreshListener {
             refreshCalDAVCalendars(false)
         }

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/activities/MainActivity.kt
@@ -87,24 +87,7 @@ class MainActivity : SimpleActivity(), RefreshRecyclerViewListener {
 
         if(hasPermission(PERMISSION_READ_CONTACTS))
         {
-            Thread{
-                    addContactEvents(true) {
-                        if (it > 0)
-                        {
-                            toast(R.string.birthdays_sync_new)
-                            updateViewPager()
-                        }
-                        else
-                        {
-                            toast(R.string.birthdays_sync_none)
-                        }
-                    }
-                }.start()
-        }
-
-        if(!hasPermission(PERMISSION_READ_CONTACTS))
-        {
-            toast(R.string.birthdays_sync_unable)
+            BirthdaysBackgroundSync()
         }
 
         swipe_refresh_layout.setOnRefreshListener {
@@ -426,6 +409,22 @@ class MainActivity : SimpleActivity(), RefreshRecyclerViewListener {
         }
     }
 
+    private fun BirthdaysBackgroundSync()
+    {
+         Thread{
+                    addContactEvents(true) {
+                        if (it > 0)
+                        {
+                            toast(R.string.birthdays_sync_new)
+                            updateViewPager()
+                        }
+                        else
+                        {
+                            toast(R.string.birthdays_sync_none)
+                        }
+                    }
+                }.start()
+    }
     private fun tryAddBirthdays() {
         handlePermission(PERMISSION_READ_CONTACTS) {
             if (it) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="app_name">Simple Calendar</string>
     <string name="app_launcher_name">Calendar</string>
     <string name="change_view">Change view</string>
@@ -84,6 +84,9 @@
     <string name="add_birthdays">Add contact birthdays</string>
     <string name="no_birthdays">No birthdays have been found</string>
     <string name="birthdays_added">Birthdays added successfully</string>
+    <string name="birthdays_sync_new" tools:ignore="MissingTranslation">New Contact\'s Birthday added</string>
+    <string name="birthdays_sync_none" tools:ignore="MissingTranslation">No new Contact\'s Birthday found</string>
+    <string name="birthdays_sync_unable" tools:ignore="MissingTranslation">"Can't sync Contact\'s birthdays. Permission denied."</string>
 
     <!-- Anniversaries -->
     <string name="anniversaries">Anniversaries</string>


### PR DESCRIPTION
When the application starts, a new Thread is started in the background after checking for PERMISSION_READ_CONTACTS. However, I believe that this can be further improved if Kotlin Coroutines were used instead of the generic Thread lambda function.