### PR TITLE
Fixes multi-day event issue when event ends at start of next day for monthly and weekly.

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/fragments/WeekFragment.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/fragments/WeekFragment.kt
@@ -420,7 +420,10 @@ class WeekFragment : Fragment(), WeeklyCalendar {
                 return
             }
 
-            val daysCnt = Days.daysBetween(Formatter.getDateTimeFromTS(minTS).toLocalDate(), Formatter.getDateTimeFromTS(maxTS).toLocalDate()).days
+            //Check if End time for event is start time for another day
+            val isStartTimeDay = Formatter.getDateTimeFromTS(maxTS) == Formatter.getDateTimeFromTS(maxTS).withTimeAtStartOfDay()
+            val numDays = Days.daysBetween(Formatter.getDateTimeFromTS(minTS).toLocalDate(), Formatter.getDateTimeFromTS(maxTS).toLocalDate()).days
+            val daysCnt = if (numDays == 1 && isStartTimeDay) 0 else numDays
             val startDateTimeInWeek = Formatter.getDateTimeFromTS(minTS)
             val firstDayIndex = (startDateTimeInWeek.dayOfWeek - if (mConfig.isSundayFirst) 0 else 1) % 7
 

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/views/MonthView.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/views/MonthView.kt
@@ -105,7 +105,8 @@ class MonthView(context: Context, attrs: AttributeSet, defStyle: Int) : View(con
                 // make sure we properly handle events lasting multiple days and repeating ones
                 val lastEvent = allEvents.lastOrNull { it.id == event.id }
                 val daysCnt = getEventLastingDaysCount(event)
-                if (lastEvent == null || lastEvent.startDayIndex + daysCnt <= day.indexOnMonthView) {
+                val validDayEvent = isDayValid(event, day.code)
+                if ((lastEvent == null || lastEvent.startDayIndex + daysCnt <= day.indexOnMonthView) && !validDayEvent) {
                     val monthViewEvent = MonthViewEvent(event.id!!, event.title, event.startTS, event.color, day.indexOnMonthView,
                             daysCnt, day.indexOnMonthView, event.getIsAllDay(), event.isPastEvent)
                     allEvents.add(monthViewEvent)
@@ -336,6 +337,14 @@ class MonthView(context: Context, attrs: AttributeSet, defStyle: Int) : View(con
         if (diff < 0) {
             eventStartDateTime = screenStartDateTime
         }
-        return Days.daysBetween(eventStartDateTime, eventEndDateTime).days + 1
+        val isMidnight = Formatter.getDateTimeFromTS(endDateTime.seconds()) == Formatter.getDateTimeFromTS(endDateTime.seconds()).withTimeAtStartOfDay()
+        val numDays = Days.daysBetween(eventStartDateTime, eventEndDateTime).days
+        val daysCnt = if (numDays == 1 && isMidnight) 0 else numDays
+        return daysCnt + 1
+    }
+
+    private fun isDayValid(event: Event, code: String): Boolean {
+        val date = Formatter.getDateTimeFromCode(code)
+        return Formatter.getDateTimeFromTS(event.endTS) == Formatter.getDateTimeFromTS(date.seconds()).withTimeAtStartOfDay()
     }
 }


### PR DESCRIPTION
#### Description 

Fixes issue #910 - Don't show events that end at 00:00 as multi day event.

#### Screenshot

#### Daily
<img width="304" alt="Screen Shot 2019-06-24 at 14 38 21" src="https://user-images.githubusercontent.com/36948493/60273835-a727da00-98ff-11e9-8d3e-239b18cc01e1.png">

#### Weekly
<img width="327" alt="Screen Shot 2019-06-24 at 14 38 36" src="https://user-images.githubusercontent.com/36948493/60273874-bc046d80-98ff-11e9-9f45-92285663e9ef.png">

#### Monthly
<img width="301" alt="Screen Shot 2019-06-24 at 14 38 45" src="https://user-images.githubusercontent.com/36948493/60273921-d2aac480-98ff-11e9-8d34-18c05dadfa71.png">

