### PR TITLE
Always shift end date by one day for all-day events

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/CalDAVHelper.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/CalDAVHelper.kt
@@ -409,7 +409,7 @@ class CalDAVHelper(val context: Context) {
                 put(CalendarContract.Events.RRULE, repeatRule)
             }
 
-            if (event.getIsAllDay() && event.endTS > event.startTS)
+            if (event.getIsAllDay() && event.endTS >= event.startTS)
                 event.endTS += DAY
 
             if (event.repeatInterval > 0) {


### PR DESCRIPTION
Without this change the end date is only shifted by one day when it is already ahead of the start date.  However, when an all-day event for a single day is created where the start and end times are equal (before selecting all-day) then the end date is not shifted by one day.  This commit changes the behaviour so that the end date is also shifted by one day in this case.

I checked that this fixes the problem described in #976.  Note that I know almost nothing about CalDAV or the internals of Simple Calendar so I might be doing something stupid.

Fixes #976.
