### PR TITLE
Feature rfc5545 classification

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -72,4 +72,5 @@ dependencies {
     kapt 'androidx.room:room-compiler:2.2.2'
     implementation 'androidx.room:room-runtime:2.2.2'
     annotationProcessor 'androidx.room:room-compiler:2.2.2'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.0-beta4'
 }

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/activities/EventActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/activities/EventActivity.kt
@@ -1092,7 +1092,8 @@ class EventActivity : SimpleActivity() {
             CONFIDENTIAL -> R.string.class_confidential
             PUBLIC -> R.string.class_public
             PRIVATE -> R.string.class_private
-            else -> R.string.class_name
+            "" -> R.string.class_server_default
+            else -> R.string.class_custom
         })
     }
 

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/activities/EventActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/activities/EventActivity.kt
@@ -64,6 +64,7 @@ class EventActivity : SimpleActivity() {
     private val EVENT_CALENDAR_ID = "EVENT_CALENDAR_ID"
     private val SELECT_TIME_ZONE_INTENT = 1
 
+    private var mClassification = PRIVATE
     private var mReminder1Minutes = REMINDER_OFF
     private var mReminder2Minutes = REMINDER_OFF
     private var mReminder3Minutes = REMINDER_OFF
@@ -217,6 +218,8 @@ class EventActivity : SimpleActivity() {
             jumpDrawablesToCurrentState()
         }
 
+        event_classification_holder.setOnClickListener{ showEditClassificationEventDialog() }
+
         updateTextColors(event_scrollview)
         updateIconColors()
         event_time_zone_image.beVisibleIf(config.allowChangingTimeZones)
@@ -270,6 +273,7 @@ class EventActivity : SimpleActivity() {
             putInt(REPEAT_RULE, mRepeatRule)
             putLong(REPEAT_LIMIT, mRepeatLimit)
 
+            putString(CLASSIFICATION ,mClassification)
             putString(ATTENDEES, getAllAttendees(false))
 
             putLong(EVENT_TYPE_ID, mEventTypeId)
@@ -333,6 +337,7 @@ class EventActivity : SimpleActivity() {
         updateEndTexts()
         updateTimeZoneText()
         updateAttendeesVisibility()
+        updateClassificationText()
     }
 
     private fun setupEditEvent() {
@@ -373,6 +378,7 @@ class EventActivity : SimpleActivity() {
         mAttendees = Gson().fromJson<ArrayList<Attendee>>(mEvent.attendees, object : TypeToken<List<Attendee>>() {}.type) ?: ArrayList()
         checkRepeatTexts(mRepeatInterval)
         checkAttendees()
+        mClassification = mEvent.classification
     }
 
     private fun setupNewEvent() {
@@ -417,6 +423,8 @@ class EventActivity : SimpleActivity() {
             }
             mEventEndDateTime = mEventStartDateTime.plusMinutes(addMinutes)
         }
+
+        mClassification = config.defaultClassification
 
         checkAttendees()
     }
@@ -772,6 +780,12 @@ class EventActivity : SimpleActivity() {
         }
     }
 
+    private fun updateEventClassification(){
+        ensureBackgroundThread {
+
+        }
+    }
+
     private fun updateCalDAVCalendar() {
         if (config.caldavSync) {
             event_caldav_calendar_image.beVisible()
@@ -1000,6 +1014,7 @@ class EventActivity : SimpleActivity() {
             lastUpdated = System.currentTimeMillis()
             source = newSource
             location = event_location.value
+            classification = mClassification
         }
 
         // recreate the event if it was moved in a different CalDAV calendar
@@ -1060,6 +1075,25 @@ class EventActivity : SimpleActivity() {
                 }
             }
         }
+    }
+
+    private fun showEditClassificationEventDialog() {
+        EditClassificationEventDialog(this, mClassification) {
+                ensureBackgroundThread {
+                    mClassification = it
+                    mEvent.classification = mClassification
+                    updateClassificationText()
+                }
+        }
+    }
+
+    private fun updateClassificationText(){
+        event_classification_type.text = getString(when (mClassification) {
+            CONFIDENTIAL -> R.string.class_confidential
+            PUBLIC -> R.string.class_public
+            PRIVATE -> R.string.class_private
+            else -> R.string.class_name
+        })
     }
 
     private fun updateStartTexts() {

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/activities/EventActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/activities/EventActivity.kt
@@ -780,12 +780,6 @@ class EventActivity : SimpleActivity() {
         }
     }
 
-    private fun updateEventClassification(){
-        ensureBackgroundThread {
-
-        }
-    }
-
     private fun updateCalDAVCalendar() {
         if (config.caldavSync) {
             event_caldav_calendar_image.beVisible()

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/activities/SettingsActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/activities/SettingsActivity.kt
@@ -8,6 +8,7 @@ import android.os.Bundle
 import android.view.Menu
 import com.simplemobiletools.calendar.pro.R
 import com.simplemobiletools.calendar.pro.dialogs.SelectCalendarsDialog
+import com.simplemobiletools.calendar.pro.dialogs.SelectClassificationDialog
 import com.simplemobiletools.calendar.pro.dialogs.SelectEventTypeDialog
 import com.simplemobiletools.calendar.pro.extensions.*
 import com.simplemobiletools.calendar.pro.helpers.*
@@ -63,6 +64,7 @@ class SettingsActivity : SimpleActivity() {
         setupDefaultStartTime()
         setupDefaultDuration()
         setupDefaultEventType()
+        setupDefaultClassification()
         setupPullToRefresh()
         setupDefaultReminder()
         setupDefaultReminder1()
@@ -655,6 +657,25 @@ class SettingsActivity : SimpleActivity() {
             }
         }
     }
+
+    private fun setupDefaultClassification() {
+        updateDefaultClassificationText()
+        settings_default_classification_holder.setOnClickListener {
+            SelectClassificationDialog(this, config.defaultClassification) {
+                config.defaultClassification = it
+                updateDefaultClassificationText()
+            }
+        }
+    }
+
+    private fun updateDefaultClassificationText() {
+        settings_default_classification.text = getString( when (config.defaultClassification.toUpperCase()) {
+            CONFIDENTIAL -> R.string.class_confidential
+            PUBLIC -> R.string.class_public
+            else -> R.string.class_private
+        })
+    }
+
 
     private fun setupExportSettings() {
         settings_export_holder.setOnClickListener {

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/activities/SettingsActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/activities/SettingsActivity.kt
@@ -676,7 +676,6 @@ class SettingsActivity : SimpleActivity() {
         })
     }
 
-
     private fun setupExportSettings() {
         settings_export_holder.setOnClickListener {
             val configItems = LinkedHashMap<String, Any>().apply {

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/dialogs/EditClassificationEventDialog.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/dialogs/EditClassificationEventDialog.kt
@@ -1,0 +1,49 @@
+package com.simplemobiletools.calendar.pro.dialogs
+
+import android.app.Activity
+import android.view.ViewGroup
+import android.widget.RadioGroup
+import androidx.appcompat.app.AlertDialog
+import com.simplemobiletools.calendar.pro.R
+import com.simplemobiletools.calendar.pro.activities.SimpleActivity
+import com.simplemobiletools.commons.extensions.hideKeyboard
+import com.simplemobiletools.commons.extensions.setupDialogStuff
+import kotlinx.android.synthetic.main.dialog_edit_classification_event.view.*
+import kotlinx.android.synthetic.main.dialog_edit_repeating_event.view.*
+
+class EditClassificationEventDialog(val activity: Activity, classificationValue: String, val callback: (classificationValue: String) -> Unit) {
+    var dialog: AlertDialog
+
+    init {
+        val view = (activity.layoutInflater.inflate(R.layout.dialog_edit_classification_event, null) as ViewGroup).apply {
+
+        }
+        val checkedId = when (classificationValue.toUpperCase()) {
+            com.simplemobiletools.calendar.pro.helpers.PUBLIC -> R.id.edit_classification_event_public
+            com.simplemobiletools.calendar.pro.helpers.CONFIDENTIAL -> R.id.edit_classification_event_confidential
+            else -> R.id.edit_classification_event_private
+        }
+        view.classification_event_radio_view.check(checkedId)
+        view.classification_event_radio_view.edit_classification_event_public.setOnClickListener{ viewClicked(view, R.id.edit_classification_event_public) }
+        view.classification_event_radio_view.edit_classification_event_private.setOnClickListener{ viewClicked(view, R.id.edit_classification_event_private) }
+        view.classification_event_radio_view.edit_classification_event_confidential.setOnClickListener{ viewClicked(view, R.id.edit_classification_event_confidential) }
+
+        dialog = AlertDialog.Builder(activity)
+                .create().apply {
+                    activity.setupDialogStuff(view, this) {
+                        hideKeyboard()
+                    }
+                }
+    }
+
+    private fun viewClicked(view: ViewGroup, classificationId: Int) {
+        view.classification_event_radio_view.check(classificationId)
+        val classificationValue = when (classificationId) {
+            R.id.edit_classification_event_private -> com.simplemobiletools.calendar.pro.helpers.PRIVATE
+            R.id.edit_classification_event_public -> com.simplemobiletools.calendar.pro.helpers.PUBLIC
+            else -> com.simplemobiletools.calendar.pro.helpers.CONFIDENTIAL
+        }
+            dialog?.dismiss()
+            callback(classificationValue)
+    }
+}

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/dialogs/EditClassificationEventDialog.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/dialogs/EditClassificationEventDialog.kt
@@ -1,6 +1,7 @@
 package com.simplemobiletools.calendar.pro.dialogs
 
 import android.app.Activity
+import android.view.View
 import android.view.ViewGroup
 import android.widget.RadioGroup
 import androidx.appcompat.app.AlertDialog
@@ -8,25 +9,35 @@ import com.simplemobiletools.calendar.pro.R
 import com.simplemobiletools.calendar.pro.activities.SimpleActivity
 import com.simplemobiletools.commons.extensions.hideKeyboard
 import com.simplemobiletools.commons.extensions.setupDialogStuff
+import kotlinx.android.synthetic.main.dialog_delete_event.view.*
 import kotlinx.android.synthetic.main.dialog_edit_classification_event.view.*
 import kotlinx.android.synthetic.main.dialog_edit_repeating_event.view.*
 
-class EditClassificationEventDialog(val activity: Activity, classificationValue: String, val callback: (classificationValue: String) -> Unit) {
+class EditClassificationEventDialog(val activity: Activity, var classificationValue: String, val callback: (classificationValue: String) -> Unit) {
     var dialog: AlertDialog
 
     init {
         val view = (activity.layoutInflater.inflate(R.layout.dialog_edit_classification_event, null) as ViewGroup).apply {
 
         }
-        val checkedId = when (classificationValue.toUpperCase()) {
+        val checkedId = when (classificationValue.trim().toUpperCase()) {
             com.simplemobiletools.calendar.pro.helpers.PUBLIC -> R.id.edit_classification_event_public
+            com.simplemobiletools.calendar.pro.helpers.PRIVATE -> R.id.edit_classification_event_private
             com.simplemobiletools.calendar.pro.helpers.CONFIDENTIAL -> R.id.edit_classification_event_confidential
-            else -> R.id.edit_classification_event_private
+            "" -> R.id.edit_classification_event_server_default
+            else -> R.id.edit_classification_event_custom
         }
         view.classification_event_radio_view.check(checkedId)
+
         view.classification_event_radio_view.edit_classification_event_public.setOnClickListener{ viewClicked(view, R.id.edit_classification_event_public) }
         view.classification_event_radio_view.edit_classification_event_private.setOnClickListener{ viewClicked(view, R.id.edit_classification_event_private) }
         view.classification_event_radio_view.edit_classification_event_confidential.setOnClickListener{ viewClicked(view, R.id.edit_classification_event_confidential) }
+        view.classification_event_radio_view.edit_classification_event_server_default.setOnClickListener{ viewClicked(view, R.id.edit_classification_event_server_default) }
+        if (view.classification_event_radio_view.checkedRadioButtonId != R.id.edit_classification_event_custom) {
+            view.classification_event_radio_view.edit_classification_event_custom.visibility = View.INVISIBLE
+        } else {
+            view.classification_event_radio_view.edit_classification_event_custom.setOnClickListener{ viewClicked(view, R.id.edit_classification_event_custom) }
+        }
 
         dialog = AlertDialog.Builder(activity)
                 .create().apply {
@@ -41,7 +52,9 @@ class EditClassificationEventDialog(val activity: Activity, classificationValue:
         val classificationValue = when (classificationId) {
             R.id.edit_classification_event_private -> com.simplemobiletools.calendar.pro.helpers.PRIVATE
             R.id.edit_classification_event_public -> com.simplemobiletools.calendar.pro.helpers.PUBLIC
-            else -> com.simplemobiletools.calendar.pro.helpers.CONFIDENTIAL
+            R.id.edit_classification_event_confidential -> com.simplemobiletools.calendar.pro.helpers.CONFIDENTIAL
+            R.id.edit_classification_event_server_default -> ""
+            else -> classificationValue
         }
             dialog?.dismiss()
             callback(classificationValue)

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/dialogs/SelectClassificationDialog.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/dialogs/SelectClassificationDialog.kt
@@ -18,42 +18,8 @@ import com.simplemobiletools.commons.views.MyCompatRadioButton
 import kotlinx.android.synthetic.main.dialog_select_radio_group.view.*
 import kotlinx.android.synthetic.main.radio_button_with_color.view.*
 
-class SelectClassificationDialog(val activity: Activity, val currClassification: String, val callback: (classification: String) -> Unit) {
-    private val dialog: AlertDialog?
-    private val radioGroup: RadioGroup
-
+class SelectClassificationDialog(val activity: Activity, currClassification: String, val callback: (classification: String) -> Unit) {
     init {
-        val view = activity.layoutInflater.inflate(R.layout.dialog_select_radio_group, null) as ViewGroup
-        radioGroup = view.dialog_radio_group
-        addRadioButton(PUBLIC, R.id.edit_classification_event_public)
-        addRadioButton(PRIVATE, R.id.edit_classification_event_private)
-        addRadioButton(CONFIDENTIAL, R.id.edit_classification_event_confidential)
-        dialog = AlertDialog.Builder(activity)
-                .create().apply {
-                    activity.setupDialogStuff(view, this)
-                }
-    }
-
-    private fun addRadioButton(classification: String, classificationId: Int) {
-        val view = activity.layoutInflater.inflate(R.layout.radio_button_with_color, null)
-        (view.dialog_radio_button as MyCompatRadioButton).apply {
-            text = classification
-            isChecked = classification.compareTo(currClassification) == 0
-            id = classificationId
-        }
-
-        view.setOnClickListener { viewClicked(classificationId) }
-        radioGroup.addView(view, RadioGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT))
-    }
-
-    private fun viewClicked(classificationId: Int) {
-        radioGroup.check(classificationId)
-        val classificationValue = when (classificationId) {
-            R.id.edit_classification_event_private -> PRIVATE
-            R.id.edit_classification_event_public -> PUBLIC
-            else -> CONFIDENTIAL
-        }
-        dialog?.dismiss()
-        callback(classificationValue)
+        EditClassificationEventDialog(activity, currClassification, callback)
     }
 }

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/dialogs/SelectClassificationDialog.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/dialogs/SelectClassificationDialog.kt
@@ -1,0 +1,59 @@
+package com.simplemobiletools.calendar.pro.dialogs
+
+import android.app.Activity
+import android.graphics.Color
+import android.view.ViewGroup
+import android.widget.RadioGroup
+import androidx.appcompat.app.AlertDialog
+import com.simplemobiletools.calendar.pro.R
+import com.simplemobiletools.calendar.pro.extensions.config
+import com.simplemobiletools.calendar.pro.helpers.CONFIDENTIAL
+import com.simplemobiletools.calendar.pro.helpers.PRIVATE
+import com.simplemobiletools.calendar.pro.helpers.PUBLIC
+import com.simplemobiletools.calendar.pro.models.EventType
+import com.simplemobiletools.commons.extensions.hideKeyboard
+import com.simplemobiletools.commons.extensions.setFillWithStroke
+import com.simplemobiletools.commons.extensions.setupDialogStuff
+import com.simplemobiletools.commons.views.MyCompatRadioButton
+import kotlinx.android.synthetic.main.dialog_select_radio_group.view.*
+import kotlinx.android.synthetic.main.radio_button_with_color.view.*
+
+class SelectClassificationDialog(val activity: Activity, val currClassification: String, val callback: (classification: String) -> Unit) {
+    private val dialog: AlertDialog?
+    private val radioGroup: RadioGroup
+
+    init {
+        val view = activity.layoutInflater.inflate(R.layout.dialog_select_radio_group, null) as ViewGroup
+        radioGroup = view.dialog_radio_group
+        addRadioButton(PUBLIC, R.id.edit_classification_event_public)
+        addRadioButton(PRIVATE, R.id.edit_classification_event_private)
+        addRadioButton(CONFIDENTIAL, R.id.edit_classification_event_confidential)
+        dialog = AlertDialog.Builder(activity)
+                .create().apply {
+                    activity.setupDialogStuff(view, this)
+                }
+    }
+
+    private fun addRadioButton(classification: String, classificationId: Int) {
+        val view = activity.layoutInflater.inflate(R.layout.radio_button_with_color, null)
+        (view.dialog_radio_button as MyCompatRadioButton).apply {
+            text = classification
+            isChecked = classification.compareTo(currClassification) == 0
+            id = classificationId
+        }
+
+        view.setOnClickListener { viewClicked(classificationId) }
+        radioGroup.addView(view, RadioGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT))
+    }
+
+    private fun viewClicked(classificationId: Int) {
+        radioGroup.check(classificationId)
+        val classificationValue = when (classificationId) {
+            R.id.edit_classification_event_private -> PRIVATE
+            R.id.edit_classification_event_public -> PUBLIC
+            else -> CONFIDENTIAL
+        }
+        dialog?.dismiss()
+        callback(classificationValue)
+    }
+}

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/CalDAVHelper.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/CalDAVHelper.kt
@@ -218,9 +218,6 @@ class CalDAVHelper(val context: Context) {
                             CalendarContract.Events.ACCESS_CONFIDENTIAL -> CONFIDENTIAL
                             else -> ""
                         }
-
-
-
                     val originalInstanceTime = cursor.getLongValue(CalendarContract.Events.ORIGINAL_INSTANCE_TIME)
                     val reminders = getCalDAVEventReminders(id)
                     val attendees = Gson().toJson(getCalDAVEventAttendees(id))

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/Config.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/Config.kt
@@ -174,4 +174,8 @@ class Config(context: Context) : BaseConfig(context) {
     var allowChangingTimeZones: Boolean
         get() = prefs.getBoolean(ALLOW_CHANGING_TIME_ZONES, false)
         set(allowChangingTimeZones) = prefs.edit().putBoolean(ALLOW_CHANGING_TIME_ZONES, allowChangingTimeZones).apply()
+
+    var defaultClassification: String
+        get() = prefs.getString(DEFAULT_CLASSIFICATION, PRIVATE)!!
+        set(defaultClassification) = prefs.edit().putString(DEFAULT_CLASSIFICATION, defaultClassification).apply()
 }

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/Constants.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/Constants.kt
@@ -73,6 +73,7 @@ const val DEFAULT_START_TIME = "default_start_time"
 const val DEFAULT_DURATION = "default_duration"
 const val DEFAULT_EVENT_TYPE_ID = "default_event_type_id"
 const val ALLOW_CHANGING_TIME_ZONES = "allow_changing_time_zones"
+const val DEFAULT_CLASSIFICATION = "default_classification"
 
 // repeat_rule for monthly and yearly repetition
 const val REPEAT_SAME_DAY = 1                           // i.e. 25th every month, or 3rd june (if yearly repetition)
@@ -114,6 +115,11 @@ const val BYMONTH = "BYMONTH"
 const val LOCATION = "LOCATION"
 const val RECURRENCE_ID = "RECURRENCE-ID"
 const val SEQUENCE = "SEQUENCE"
+// RFC5545#section-3.8.1.3
+const val CLASSIFICATION = "CLASS"
+const val PUBLIC = "PUBLIC"
+const val PRIVATE = "PRIVATE"
+const val CONFIDENTIAL = "CONFIDENTIAL"
 
 // this tag isn't a standard ICS tag, but there's no official way of adding a category color in an ics file
 const val CATEGORY_COLOR = "CATEGORY_COLOR:"

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/IcsExporter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/IcsExporter.kt
@@ -51,6 +51,7 @@ class IcsExporter {
                         event.eventType.let { out.writeLn("$CATEGORIES${activity.eventTypesDB.getEventTypeWithId(it)?.title}") }
                         event.lastUpdated.let { out.writeLn("$LAST_MODIFIED:${Formatter.getExportedTime(it)}") }
                         event.location.let { if (it.isNotEmpty()) out.writeLn("$LOCATION:$it") }
+                        event.classification.let { out.writeLn("$CLASSIFICATION:$it") }
 
                         if (event.getIsAllDay()) {
                             out.writeLn("$DTSTART;$VALUE=$DATE:${Formatter.getDayCodeFromTS(event.startTS)}")

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/IcsExporter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/IcsExporter.kt
@@ -51,7 +51,7 @@ class IcsExporter {
                         event.eventType.let { out.writeLn("$CATEGORIES${activity.eventTypesDB.getEventTypeWithId(it)?.title}") }
                         event.lastUpdated.let { out.writeLn("$LAST_MODIFIED:${Formatter.getExportedTime(it)}") }
                         event.location.let { if (it.isNotEmpty()) out.writeLn("$LOCATION:$it") }
-                        event.classification.let { out.writeLn("$CLASSIFICATION:$it") }
+                        event.classification.let { if (it.compareTo("") > 0) {out.writeLn("$CLASSIFICATION:$it") }}
 
                         if (event.getIsAllDay()) {
                             out.writeLn("$DTSTART;$VALUE=$DATE:${Formatter.getDayCodeFromTS(event.startTS)}")

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/IcsImporter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/IcsImporter.kt
@@ -28,6 +28,7 @@ class IcsImporter(val activity: SimpleActivity) {
     private var curRecurrenceDayCode = ""
     private var curRrule = ""
     private var curFlags = 0
+    private var curClassification = ""
     private var curReminderMinutes = ArrayList<Int>()
     private var curReminderActions = ArrayList<Int>()
     private var curRepeatExceptions = ArrayList<String>()
@@ -151,6 +152,11 @@ class IcsImporter(val activity: SimpleActivity) {
                         if (isProperReminderAction && curReminderTriggerMinutes != REMINDER_OFF) {
                             curReminderMinutes.add(curReminderTriggerMinutes)
                             curReminderActions.add(curReminderTriggerAction)
+                        }
+                    } else if (line.startsWith(CLASSIFICATION)) {
+                        val classValue = line.substring(CLASSIFICATION.length).toUpperCase()
+                        if (classValue.compareTo(PRIVATE) == 0 || classValue.compareTo(PUBLIC) == 0 || classValue.compareTo(CONFIDENTIAL) == 0) {
+                            curClassification = classValue
                         }
                     } else if (line == END_EVENT) {
                         isParsingEvent = false

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/models/Event.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/models/Event.kt
@@ -37,7 +37,8 @@ data class Event(
         @ColumnInfo(name = "event_type") var eventType: Long = REGULAR_EVENT_TYPE_ID,
         @ColumnInfo(name = "parent_id") var parentId: Long = 0,
         @ColumnInfo(name = "last_updated") var lastUpdated: Long = 0L,
-        @ColumnInfo(name = "source") var source: String = SOURCE_SIMPLE_CALENDAR)
+        @ColumnInfo(name = "source") var source: String = SOURCE_SIMPLE_CALENDAR,
+        @ColumnInfo(name = "classification") var classification: String = "")
     : Serializable {
 
     companion object {

--- a/app/src/main/res/layout/activity_event.xml
+++ b/app/src/main/res/layout/activity_event.xml
@@ -547,5 +547,58 @@
             android:layout_below="@+id/event_type_holder"
             android:background="@color/divider_grey"
             android:importantForAccessibility="no"/>
+
+        <ImageView
+            android:id="@+id/event_classification_image"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:layout_below="@+id/event_type_divider"
+            android:layout_alignTop="@+id/event_classification_holder"
+            android:layout_alignBottom="@+id/event_classification_holder"
+            android:layout_marginStart="@dimen/normal_margin"
+            android:padding="@dimen/medium_margin"
+            android:src="@drawable/ic_share_vector"/>
+
+        <RelativeLayout
+            android:id="@+id/event_classification_holder"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@+id/event_type_divider"
+            android:layout_marginTop="@dimen/medium_margin"
+            android:layout_marginBottom="@dimen/medium_margin"
+            android:layout_toEndOf="@+id/event_classification_image"
+            android:background="?attr/selectableItemBackground">
+
+            <com.simplemobiletools.commons.views.MyTextView
+                android:id="@+id/event_classification_type"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/small_margin"
+                android:layout_marginEnd="@dimen/medium_margin"
+                android:layout_toStartOf="@+id/event_classification_type_image"
+                android:paddingTop="@dimen/normal_margin"
+                android:paddingBottom="@dimen/normal_margin"
+                android:textSize="@dimen/day_text_size"/>
+
+            <ImageView
+                android:id="@+id/event_classification_type_image"
+                android:layout_width="@dimen/color_sample_size"
+                android:layout_height="@dimen/color_sample_size"
+                android:layout_alignParentEnd="true"
+                android:layout_centerVertical="true"
+                android:layout_marginEnd="@dimen/activity_margin"
+                android:clickable="false"/>
+
+        </RelativeLayout>
+        <ImageView
+            android:id="@+id/event_classification_divider"
+            android:layout_width="match_parent"
+            android:layout_height="1px"
+            android:layout_below="@+id/event_classification_holder"
+            android:layout_marginTop="@dimen/medium_margin"
+            android:background="@color/divider_grey"
+            android:importantForAccessibility="no"/>
     </RelativeLayout>
+
+
 </ScrollView>

--- a/app/src/main/res/layout/activity_event.xml
+++ b/app/src/main/res/layout/activity_event.xml
@@ -599,6 +599,4 @@
             android:background="@color/divider_grey"
             android:importantForAccessibility="no"/>
     </RelativeLayout>
-
-
 </ScrollView>

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -640,7 +640,7 @@
                 android:layout_marginEnd="@dimen/small_margin"
                 android:background="@null"
                 android:clickable="false"
-                tools:text="@string/last_used_one"/>
+                tools:text="@string/class_private"/>
 
         </RelativeLayout>
 

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -612,6 +612,38 @@
 
         </RelativeLayout>
 
+        <RelativeLayout
+            android:id="@+id/settings_default_classification_holder"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="?attr/selectableItemBackground"
+            android:paddingLeft="@dimen/normal_margin"
+            android:paddingTop="@dimen/bigger_margin"
+            android:paddingRight="@dimen/normal_margin"
+            android:paddingBottom="@dimen/bigger_margin">
+
+            <com.simplemobiletools.commons.views.MyTextView
+                android:id="@+id/settings_default_classification_label"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_centerVertical="true"
+                android:layout_toStartOf="@+id/settings_default_classification"
+                android:paddingLeft="@dimen/medium_margin"
+                android:paddingRight="@dimen/medium_margin"
+                android:text="@string/default_classification"/>
+
+            <com.simplemobiletools.commons.views.MyTextView
+                android:id="@+id/settings_default_classification"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentEnd="true"
+                android:layout_marginEnd="@dimen/small_margin"
+                android:background="@null"
+                android:clickable="false"
+                tools:text="@string/last_used_one"/>
+
+        </RelativeLayout>
+
         <View
             android:id="@+id/weekly_view_divider"
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/dialog_edit_classification_event.xml
+++ b/app/src/main/res/layout/dialog_edit_classification_event.xml
@@ -17,6 +17,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="@string/class_name"
+            android:textAlignment="center"
             android:textSize="@dimen/bigger_text_size" />
 
         <RadioGroup
@@ -48,6 +49,23 @@
                 android:paddingTop="@dimen/normal_margin"
                 android:paddingBottom="@dimen/normal_margin"
                 android:text="@string/class_confidential" />
+
+            <com.simplemobiletools.commons.views.MyCompatRadioButton
+                android:id="@+id/edit_classification_event_server_default"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingTop="@dimen/normal_margin"
+                android:paddingBottom="@dimen/normal_margin"
+                android:text="@string/class_server_default" />
+
+            <com.simplemobiletools.commons.views.MyCompatRadioButton
+                android:id="@+id/edit_classification_event_custom"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingTop="@dimen/normal_margin"
+                android:paddingBottom="@dimen/normal_margin"
+                android:text="@string/class_custom" />
+
         </RadioGroup>
     </LinearLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/dialog_edit_classification_event.xml
+++ b/app/src/main/res/layout/dialog_edit_classification_event.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="match_parent" android:layout_height="match_parent">
+
+    <LinearLayout
+        android:id="@+id/edit_classification_event_holder"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingStart="@dimen/big_margin"
+        android:paddingTop="@dimen/big_margin"
+        android:paddingEnd="@dimen/big_margin">
+
+        <com.simplemobiletools.commons.views.MyTextView
+            android:id="@+id/edit_classification_event_description"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/class_name"
+            android:textSize="@dimen/bigger_text_size" />
+
+        <RadioGroup
+            android:id="@+id/classification_event_radio_view"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <com.simplemobiletools.commons.views.MyCompatRadioButton
+                android:id="@+id/edit_classification_event_public"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:checked="true"
+                android:paddingTop="@dimen/normal_margin"
+                android:paddingBottom="@dimen/normal_margin"
+                android:text="@string/class_public" />
+
+            <com.simplemobiletools.commons.views.MyCompatRadioButton
+                android:id="@+id/edit_classification_event_private"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingTop="@dimen/normal_margin"
+                android:paddingBottom="@dimen/normal_margin"
+                android:text="@string/class_private" />
+
+            <com.simplemobiletools.commons.views.MyCompatRadioButton
+                android:id="@+id/edit_classification_event_confidential"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingTop="@dimen/normal_margin"
+                android:paddingBottom="@dimen/normal_margin"
+                android:text="@string/class_confidential" />
+        </RadioGroup>
+    </LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -293,6 +293,10 @@
         <b>Reddit:</b>
         https://www.reddit.com/r/SimpleMobileTools
     </string>
+    <string name="class_private">Privat</string>
+    <string name="class_public">Öffentlich</string>
+    <string name="class_confidential">Vertraulich</string>
+    <string name="class_name">Klassifizierung</string>
 
     <!--
         Haven't found some strings? There's more at

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -109,6 +109,14 @@
     <string name="maybe_going">Maybe going</string>
     <string name="invited">Invited</string>
 
+    <!-- Event Classification RFC5545 -->
+    <string name="class_public">Public Event (visible)</string>
+    <string name="class_private">Show Date and Time Only (visible)</string>
+    <string name="class_confidential">Private Event (hidden)</string>
+    <string name="class_unknown">Visibility Unknown / Not Set</string>
+    <string name="class_name">Visibility of the event:</string>
+
+
     <!-- Time zones -->
     <string name="enter_a_country">Enter a country or time zone</string>
 
@@ -292,6 +300,7 @@
         <b>Reddit:</b>
         https://www.reddit.com/r/SimpleMobileTools
     </string>
+    <string name="default_classification">Default Classification</string>
 
     <!--
         Haven't found some strings? There's more at

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -110,11 +110,12 @@
     <string name="invited">Invited</string>
 
     <!-- Event Classification RFC5545 -->
-    <string name="class_public">Public Event (visible)</string>
-    <string name="class_private">Show Date and Time Only (visible)</string>
-    <string name="class_confidential">Private Event (hidden)</string>
-    <string name="class_unknown">Visibility Unknown / Not Set</string>
-    <string name="class_name">Visibility of the event:</string>
+    <string name="class_public">Public: event visible to others</string>
+    <string name="class_confidential">Confidential: only date and time visible to others</string>
+    <string name="class_private">Private: event hidden from others</string>
+    <string name="class_custom">Custom: unknown visibility properties</string>
+    <string name="class_server_default">Server defaults: unknown visibility properties</string>
+    <string name="class_name">Visibility of the event in shared calendars.</string>
 
 
     <!-- Time zones -->
@@ -201,6 +202,8 @@
     <string name="other_time">Other time</string>
     <string name="highlight_weekends">Highlight weekends on some views</string>
     <string name="allow_changing_time_zones">Allow changing event time zones</string>
+    <string name="default_classification">Default visibility in shared calendars</string>
+
 
     <!-- CalDAV sync -->
     <string name="caldav">CalDAV</string>
@@ -300,8 +303,6 @@
         <b>Reddit:</b>
         https://www.reddit.com/r/SimpleMobileTools
     </string>
-    <string name="default_classification">Default Classification</string>
-
     <!--
         Haven't found some strings? There's more at
         https://github.com/SimpleMobileTools/Simple-Commons/tree/master/commons/src/main/res

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -117,7 +117,6 @@
     <string name="class_server_default">Server defaults: unknown visibility properties</string>
     <string name="class_name">Visibility of the event in shared calendars.</string>
 
-
     <!-- Time zones -->
     <string name="enter_a_country">Enter a country or time zone</string>
 
@@ -203,7 +202,6 @@
     <string name="highlight_weekends">Highlight weekends on some views</string>
     <string name="allow_changing_time_zones">Allow changing event time zones</string>
     <string name="default_classification">Default visibility in shared calendars</string>
-
 
     <!-- CalDAV sync -->
     <string name="caldav">CalDAV</string>

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath 'com.android.tools.build:gradle:3.6.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "de.timfreiheit.resourceplaceholders:placeholders:0.3"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Aug 25 21:51:10 CEST 2019
+#Fri Mar 13 11:49:50 CET 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip


### PR DESCRIPTION
Added support to decide on the access level of an event in shared calendars https://github.com/SimpleMobileTools/Simple-Calendar/issues/1022.

Added support for:
- RFC5545#section-3.8.1.3 Classification together with ICS import & export
- CalDav accessLevel

Integrated support in:
- Event editor
- Global settings

Tested:
- [x] ICS Import
- [x] ICS Export
- [x] CalDav Sync with Nextcloud calendar implementation

Screenshots:
![Event Editor](https://user-images.githubusercontent.com/17083784/77106320-2d9cc280-6a1f-11ea-8b0e-60a0b8574dbf.jpg)

![Settings](https://user-images.githubusercontent.com/17083784/77106387-49a06400-6a1f-11ea-932d-9ec6bc18b0be.jpg)

![Settings Choice](https://user-images.githubusercontent.com/17083784/77106395-4c9b5480-6a1f-11ea-9cc9-ec2a51aeaace.jpg)

