### PR TITLE
changed German and French translations

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -99,7 +99,7 @@
     <string name="reminder">Erinnerung</string>
     <string name="before">vorher</string>
     <string name="add_another_reminder">Weitere Erinnerung hinzufügen</string>
-    <string name="event_reminders">Termin-Erinnerungen</string>
+    <string name="event_reminders">Terminerinnerungen</string>
 
     <!-- Event attendees -->
     <string name="add_another_attendee">Teilnehmer hinzufügen</string>
@@ -110,14 +110,14 @@
     <string name="invited">Eingeladen</string>
 
     <!-- Time zones -->
-    <string name="enter_a_country">Enter a country or time zone</string>
+    <string name="enter_a_country">Region, Stadt oder Zeitversatz eingeben</string>
 
     <!-- Export / Import -->
     <string name="import_events">Termine importieren</string>
     <string name="export_events">Termine exportieren</string>
-    <string name="import_events_from_ics">Termine aus .ics-Datei importieren</string>
-    <string name="export_events_to_ics">Termine als .ics-Datei exportieren</string>
-    <string name="default_event_type">Standard-Termintyp</string>
+    <string name="import_events_from_ics">Termine aus ics-Datei importieren</string>
+    <string name="export_events_to_ics">Termine als ics-Datei exportieren</string>
+    <string name="default_event_type">Standardtermintyp</string>
     <string name="export_past_events_too">Vergangene Termine auch exportieren</string>
     <string name="include_event_types">Termintypen miteinbeziehen</string>
     <string name="filename_without_ics">Dateiname (ohne .ics)</string>
@@ -138,9 +138,9 @@
     <string name="type_already_exists">Typ mit diesem Namen existiert bereits</string>
     <string name="color">Farbe</string>
     <string name="regular_event">Regulärer Termin</string>
-    <string name="cannot_delete_default_type">Standard-Termintyp kann nicht gelöscht werden</string>
+    <string name="cannot_delete_default_type">Standardtermintyp kann nicht gelöscht werden</string>
     <string name="select_event_type">Wähle einen Termintyp aus</string>
-    <string name="move_events_into_default">Betroffene Termine in den Standard-Termintyp verschieben</string>
+    <string name="move_events_into_default">Betroffene Termine in den Standardtermintyp verschieben</string>
     <string name="remove_affected_events">Betroffene Termine dauerhaft löschen</string>
     <string name="unsync_caldav_calendar">Um einen CalDAV-Kalender zu entfernen, musst du ihn desynchronisieren</string>
 
@@ -173,7 +173,7 @@
     <string name="loop_reminders">Erinnerungen wiederholen bis sie verworfen werden</string>
     <string name="dim_past_events">Vergangene Termine ausgrauen</string>
     <string name="events">Termine</string>
-    <string name="reminder_stream">Audio-Ausgabekanal für Erinnerungen</string>
+    <string name="reminder_stream">Audioausgabekanal für Erinnerungen</string>
     <string name="system_stream">Medien</string>
     <string name="alarm_stream">Wecker</string>
     <string name="notification_stream">Benachrichtigung</string>
@@ -185,13 +185,13 @@
     <string name="view_to_open_from_widget">Ansicht beim Öffnen durch das Terminlisten-Widget</string>
     <string name="last_view">Letzte Ansicht</string>
     <string name="new_events">Neue Termine</string>
-    <string name="default_start_time">Standard-Anfangszeit</string>
+    <string name="default_start_time">Standardanfangszeit</string>
     <string name="next_full_hour">Nächste volle Stunde</string>
-    <string name="default_duration">Standard-Dauer</string>
+    <string name="default_duration">Standarddauer</string>
     <string name="last_used_one">Zuletzt verwendete</string>
     <string name="other_time">Andere Zeit</string>
     <string name="highlight_weekends">Wochenenden in einigen Ansichten hervorheben</string>
-    <string name="allow_changing_time_zones">Allow changing event time zones</string>
+    <string name="allow_changing_time_zones">Zeitzone kann geändert werden</string>
 
     <!-- CalDAV sync -->
     <string name="caldav">CalDAV</string>
@@ -206,7 +206,7 @@
     <string name="synchronization_completed">Synchronisation erfolgreich</string>
     <string name="select_a_different_caldav_color">Wähle eine andere Farbe (wird möglicherweise nur lokal angewendet)</string>
     <string name="insufficient_permissions">Dir fehlt die Berechtigung zum Ändern des gewählten Kalenders</string>
-    <string name="caldav_event_not_found">Event not found. Please enable CalDAV sync for the appropriate calendar in the app settings.</string>
+    <string name="caldav_event_not_found">Der Termin wurde nicht gefunden. Bitte aktiviere die Synchronisierung für den Kalender in den Einstellungen.</string>
 
     <!-- alternative versions for some languages, use the same translations if you are not sure what this means -->
     <!-- used in repetition, like "Every last Sunday" -->
@@ -238,10 +238,10 @@
         Für andere Kalender benötigst du einen Synchronisierungsadapter, wie z. B. DAVx5.</string>
     <string name="faq_3_title">Ich sehe die Erinnerungen, aber ich höre keinen Ton. Was kann ich tun?</string>
     <string name="faq_3_text">Erinnerungen nicht nur anzeigen, sondern Töne dazu abspielen ist ebenfalls stark vom jeweiligen (Android) System abhängig. Wenn Du keine Töne hörst, versuche in den App Einstellungen,
-        die Option \"Audio-Ausgabekanal für Erinnerungen\" anzuklicken und eine andere Option auszuwählen. Wenn das immer noch nichts ändert, prüfe Deine Lautstärkeeinstellungen. of der gewählte Kanal nicht auf lautlos steht.</string>
-    <string name="faq_4_title">Does the app support time zones?</string>
-    <string name="faq_4_text">Yes, it does. By default all events are created in your current time zone. If you want to change an events\' time zone,
-        you will first have to enable the time zone picker at the app settings, then change it at the Event Details screen. It is disabled by default as most people won\'t need it.</string>
+        die Option \"Audioausgabekanal für Erinnerungen\" anzuklicken und eine andere Option auszuwählen. Wenn das immer noch nichts ändert, prüfe Deine Lautstärkeeinstellungen. of der gewählte Kanal nicht auf lautlos steht.</string>
+    <string name="faq_4_title">Unterstützt diese Kalender-App Zeitzonen?</string>
+    <string name="faq_4_text">Ja. Standardmäßig werden alle neuen Termine in der aktuellen Zeitzone des Gerätes erstellt. Um die Zeitzone eines Termins ändern zu können muss die Option \"Zeitzone kann geändert werden\"
+        in den Einstellungen aktiviert sein. Die Zeitzone eines Termins kann dann beim Anlegen oder Bearbeiten geändert werden. In den Standardeinstellungen ist dies nicht aktiv, da die meisten Anwender die Möglichkeit nicht benötigen werden.</string>
 
     <!-- Strings displayed only on Google Playstore. Optional, but good to have -->
     <!-- App title has to have less than 50 characters. If you cannot squeeze it, just remove a part of it -->
@@ -283,7 +283,7 @@
         <b>Einen Überblick über die komplette Suite von Simple Tools gibt es hier:</b>
         https://www.simplemobiletools.com
 
-        <b>Standalone website of Simple Calendar Pro:</b>
+        <b>Eigene Website von Simple Calendar Pro:</b>
         https://www.simplemobiletools.com/calendar
 
         <b>Facebook:</b>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -86,14 +86,14 @@
     <string name="birthdays">Anniversaires</string>
     <string name="add_birthdays">Ajouter les anniversaires des contacts</string>
     <string name="no_birthdays">Aucun anniversaire n\’a été trouvé</string>
-    <string name="no_new_birthdays">Aucun nouvel anniversaire n'a été trouvé</string>
+    <string name="no_new_birthdays">Aucun nouvel anniversaire n’a été trouvé</string>
     <string name="birthdays_added">Anniversaires ajoutés avec succès</string>
 
     <!-- Anniversaries -->
     <string name="anniversaries">Anniversaires d\’évènements</string>
     <string name="add_anniversaries">Ajouter des anniversaires d\’évènements de contact</string>
     <string name="no_anniversaries">Aucun anniversaire d\’évènements n\’a été trouvé</string>
-    <string name="no_new_anniversaries">Aucun nouvel anniversaire n'a été trouvé</string>
+    <string name="no_new_anniversaries">Aucun nouvel anniversaire n’a été trouvé</string>
     <string name="anniversaries_added">Anniversaires d\’évènements ajoutés avec succès</string>
 
     <!-- Event Reminders -->
@@ -207,7 +207,7 @@
     <string name="synchronization_completed">La synchronisation est terminée</string>
     <string name="select_a_different_caldav_color">Sélectionnez une couleur différente (peut être appliqué localement uniquement)</string>
     <string name="insufficient_permissions">Vous n\’êtes pas autorisé à écrire dans l\’agenda sélectionné</string>
-    <string name="caldav_event_not_found">Événement introuvable. Veuillez activer la synchronisation CalDAV pour le calendrier approprié dans les paramètres de l'application.</string>
+    <string name="caldav_event_not_found">Événement introuvable. Veuillez activer la synchronisation CalDAV pour le calendrier approprié dans les paramètres de l’application.</string>
 
     <!-- alternative versions for some languages, use the same translations if you are not sure what this means -->
     <!-- used in repetition, like "Every last Sunday" -->
@@ -239,8 +239,8 @@
     <string name="faq_3_title">Je vois les rappels visuels, mais n\’entends aucun son. Que puis-je faire ?</string>
     <string name="faq_3_text">Pas seulement l\’affichage du rappel, mais la lecture de l\’audio est également énormément affectée par le système. Si vous n’entendez aucun son, essayez d’entrer dans les paramètres de l’appli,
         en appuyant sur l\’option « Flux audio utilisé par les rappels » et en la modifiant. Si cela ne fonctionne toujours pas, vérifiez vos paramètres audio, si le flux particulier n’est pas mis en sourdine.</string>
-    <string name="faq_4_title">L'application prend-elle en charge les fuseaux horaires?</string>
-    <string name="faq_4_text">Oui. Par défaut, tous les événements sont créés dans votre fuseau horaire actuel. Si vous souhaitez modifier le fuseau horaire d'un événement, vous devez d'abord activer le sélecteur de fuseau horaire dans les paramètres de l'application, puis le modifier sur l'écran Détails de l'événement. Il est désactivé par défaut car la plupart des gens n'en auront pas besoin.</string>
+    <string name="faq_4_title">L’application prend-elle en charge les fuseaux horaires?</string>
+    <string name="faq_4_text">Oui. Par défaut, tous les événements sont créés dans votre fuseau horaire actuel. Si vous souhaitez modifier le fuseau horaire d’un événement, vous devez d’abord activer le sélecteur de fuseau horaire dans les paramètres de l’application, puis le modifier sur l’écran Détails de l’événement. Il est désactivé par défaut car la plupart des gens n’en auront pas besoin.</string>
 
     <!-- Strings displayed only on Google Playstore. Optional, but good to have -->
     <!-- App title has to have less than 50 characters. If you cannot squeeze it, just remove a part of it -->


### PR DESCRIPTION
German: removed inappropriate hyphens and added missing translations
French: changed unescaped single quotes to apostrophes
