### PR TITLE
modified day code validation for multi day events to fix 1164

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/fragments/WeekFragment.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/fragments/WeekFragment.kt
@@ -595,8 +595,9 @@ class WeekFragment : Fragment(), WeeklyCalendar {
                 }
             }
 
-            val dayCode = Formatter.getDayCodeFromDateTime(startDateTime)
-            val dayOfWeek = dayColumns.indexOfFirst { it.tag == dayCode }
+            val dayCodeStart = Formatter.getDayCodeFromDateTime(startDateTime).toInt()
+            val dayCodeEnd = Formatter.getDayCodeFromDateTime(endDateTime).toInt()
+            val dayOfWeek = dayColumns.indexOfFirst { it.tag.toInt() == dayCodeStart || (it.tag.toInt() > dayCodeStart && it.tag.toInt() <= dayCodeEnd) }
             if (dayOfWeek == -1) {
                 return
             }


### PR DESCRIPTION
fixes #1164 by an additional dayCode range check.
Probably just a hot fix, because it converts string dayCode to int for range comparison.
Converting dayCoulum tag to date time would also work.