### PR TITLE
Fixes #1170 Contact birthday not correct on changing timezone

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/Formatter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/Formatter.kt
@@ -85,6 +85,8 @@ object Formatter {
 
     fun getDateTimeFromTS(ts: Long) = DateTime(ts * 1000L, DateTimeZone.getDefault())
 
+    fun getDateTimeFromTSForATimeZone(ts: Long, timeZoneId: String) = DateTime(ts * 1000L, DateTimeZone.forID(timeZoneId))
+
     fun getUTCDateTimeFromTS(ts: Long) = DateTime(ts * 1000L, DateTimeZone.UTC)
 
     // use manually translated month names, as DateFormat and Joda have issues with a lot of languages

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/MonthlyCalendarImpl.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/MonthlyCalendarImpl.kt
@@ -84,8 +84,8 @@ class MonthlyCalendarImpl(val callback: MonthlyCalendar, val context: Context) {
     private fun markDaysWithEvents(days: ArrayList<DayMonthly>) {
         val dayEvents = HashMap<String, ArrayList<Event>>()
         mEvents.forEach {
-            val startDateTime = Formatter.getDateTimeFromTS(it.startTS)
-            val endDateTime = Formatter.getDateTimeFromTS(it.endTS)
+            val startDateTime = Formatter.getDateTimeFromTSForATimeZone(it.startTS, it.timeZone)
+            val endDateTime = Formatter.getDateTimeFromTSForATimeZone(it.endTS, it.timeZone)
             val endCode = Formatter.getDayCodeFromDateTime(endDateTime)
 
             var currDay = startDateTime


### PR DESCRIPTION
The birthday was captured in DB with current time zone. While retrieving the date was parsed based on the current time zone. Modified that logic to parse date based on the timezone at which it was originally captured