### PR TITLE
fix second sutarday and sunday are not highlighted in weekly view

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/Constants.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/Constants.kt
@@ -164,9 +164,5 @@ const val REMINDER_EMAIL = 1
 fun getNowSeconds() = System.currentTimeMillis() / 1000L
 
 fun isWeekend(i: Int, isSundayFirst: Boolean): Boolean {
-    return if (isSundayFirst) {
-        i == 0 || i == 6
-    } else {
-        i == 5 || i == 6
-    }
+    return (i + if (isSundayFirst) 6 else 0) % 7 > 4
 }

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/Constants.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/Constants.kt
@@ -164,5 +164,9 @@ const val REMINDER_EMAIL = 1
 fun getNowSeconds() = System.currentTimeMillis() / 1000L
 
 fun isWeekend(i: Int, isSundayFirst: Boolean): Boolean {
-    return (i + if (isSundayFirst) 6 else 0) % 7 > 4
+    return if (isSundayFirst) {
+        i == 0 || i == 6 || i == 7 || i == 13
+    } else {
+        i == 5 || i == 6 || i == 12 || i == 13
+    }
 }


### PR DESCRIPTION
When you show more than 7 days in weekly view, second Saturday and Sunday are not highlighted even if you set highlight weekends option.
![WeeklyView](https://user-images.githubusercontent.com/842511/110630659-ff446400-81e8-11eb-920e-1d263c452cad.png)
 