### PR TITLE
fix default color in color picker of CalDAV event type

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/dialogs/SelectEventTypeColorDialog.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/dialogs/SelectEventTypeColorDialog.kt
@@ -68,7 +68,7 @@ class SelectEventTypeColorDialog(val activity: Activity, val eventType: EventTyp
     }
 
     private fun showCustomColorPicker() {
-        ColorPickerDialog(activity, activity.config.primaryColor) { wasPositivePressed, color ->
+        ColorPickerDialog(activity, eventType.color) { wasPositivePressed, color ->
             if (wasPositivePressed) {
                 callback(color)
             }


### PR DESCRIPTION
When I change colors of CalDAV event types, color picker dialog always starts with the same color regardless current event type's color.