### PR TITLE
fix #1332 : concurrent zero duration in week view

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/extensions/Range.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/extensions/Range.kt
@@ -2,4 +2,4 @@ package com.simplemobiletools.calendar.pro.extensions
 
 import android.util.Range
 
-fun Range<Int>.touch(other: Range<Int>) = (upper >= other.lower && lower <= other.upper) || (other.upper >= lower && other.lower <= upper)
+fun Range<Int>.touch(other: Range<Int>) = (upper > other.lower && lower < other.upper) || (other.upper > lower && other.lower < upper)

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/fragments/WeekFragment.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/fragments/WeekFragment.kt
@@ -402,7 +402,7 @@ class WeekFragment : Fragment(), WeeklyCalendar {
             if (!event.getIsAllDay() && Formatter.getDayCodeFromDateTime(startDateTime) == Formatter.getDayCodeFromDateTime(endDateTime)) {
                 val startMinutes = startDateTime.minuteOfDay
                 val duration = endDateTime.minuteOfDay - startMinutes
-                val range = Range(startMinutes, startMinutes + duration)
+                val range = Range(startMinutes, startMinutes + maxOf(1, duration))
                 val eventWeekly = EventWeeklyView(event.id!!, range)
 
                 val dayCode = Formatter.getDayCodeFromDateTime(startDateTime)
@@ -428,7 +428,7 @@ class WeekFragment : Fragment(), WeeklyCalendar {
 
                 val startMinutes = startDateTime.minuteOfDay
                 val duration = endDateTime.minuteOfDay - startMinutes
-                val range = Range(startMinutes, startMinutes + duration)
+                val range = Range(startMinutes, startMinutes + maxOf(1, duration))
 
                 var overlappingEvents = 0
                 var currentEventOverlapIndex = 0


### PR DESCRIPTION
The range comparison did not include the equal case.
Changed < to <= and > to >=