### PR TITLE
added missing German strings plus two updates

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -6,9 +6,9 @@
     <string name="daily_view">Tagesansicht</string>
     <string name="weekly_view">Wochenansicht</string>
     <string name="monthly_view">Monatsansicht</string>
-    <string name="monthly_daily_view">Monthly + daily view</string>
+    <string name="monthly_daily_view">kompakte Monatsansicht mit Tagesliste</string>
     <string name="yearly_view">Jahresansicht</string>
-    <string name="simple_event_list">Einfache Terminliste</string>
+    <string name="simple_event_list">Terminliste</string>
     <string name="no_upcoming_events">Scheint so, als hättest du keine anstehenden Termine.</string>
     <string name="go_to_today">Springe zu Heute</string>
     <string name="go_to_date">Springe zu einem Datum</string>
@@ -16,7 +16,7 @@
 
     <!-- Widget titles -->
     <string name="widget_monthly">Monatskalender</string>
-    <string name="widget_list">Termin-Liste</string>
+    <string name="widget_list">Terminliste</string>
     <string name="widget_todays_date">Kalender heutiges Datum</string>
 
     <!-- Event -->
@@ -51,7 +51,7 @@
     <string name="delete_future_occurrences">Diese und zukünftige Wiederholungen löschen</string>
     <string name="delete_all_occurrences">Alle Wiederholungen löschen</string>
     <string name="update_one_only">Nur die ausgewählte Wiederholung ändern</string>
-    <string name="update_this_and_future_occurrences">Update this and all future occurrences</string>
+    <string name="update_this_and_future_occurrences">Diese und alle zukünftigen Instanzen ändern</string>
     <string name="update_all_occurrences">Alle Wiederholungen ändern</string>
     <string name="repeat_till_date">Bis zu bestimmtem Datum wiederholen</string>
     <string name="stop_repeating_after_x">Stopp nach x Wiederholungen</string>
@@ -72,7 +72,7 @@
     <string name="second_m">zweiten</string>
     <string name="third_m">dritten</string>
     <string name="fourth_m">vierten</string>
-    <string name="fifth_m">fifth</string>
+    <string name="fifth_m">fünften</string>
     <string name="last_m">letzten</string>
 
     <!-- alternative versions for some languages, use the same translations if you are not sure what this means -->
@@ -83,7 +83,7 @@
     <string name="second_f">zweiten</string>
     <string name="third_f">dritten</string>
     <string name="fourth_f">vierten</string>
-    <string name="fifth_f">fifth</string>
+    <string name="fifth_f">fünften</string>
     <string name="last_f">letzten</string>
 
     <!-- Birthdays -->
@@ -193,7 +193,7 @@
     <string name="new_events">Neue Termine</string>
     <string name="default_start_time">Standardanfangszeit</string>
     <string name="next_full_hour">Nächste volle Stunde</string>
-    <string name="current_time">Current time</string>
+    <string name="current_time">Aktuelle Zeit</string>
     <string name="default_duration">Standarddauer</string>
     <string name="last_used_one">Zuletzt verwendete</string>
     <string name="other_time">Andere Zeit</string>


### PR DESCRIPTION
update
- removed simple from "Einfache Terminliste", as there is no other list
- removed hyphen in Termin-Liste, as hyphens are uncommon in German

added missing translations
