### PR TITLE
Fix: popup window closes on orientation change

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -44,6 +44,7 @@
 
         <activity
             android:name=".activities.MainActivity"
+            android:configChanges="screenSize|orientation"
             android:launchMode="singleTask">
             <meta-data
                 android:name="android.app.default_searchable"


### PR DESCRIPTION
Steps to Reproduce;
1. Click on Action Menu items button
2. Rotate the screen
3. Popup window is closed

