### PR TITLE
Fix #1385, cancel notification and pending intent if event is deleted

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/EventsHelper.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/EventsHelper.kt
@@ -181,7 +181,8 @@ class EventsHelper(val context: Context) {
     fun addEventRepeatLimit(eventId: Long, limitTS: Long) {
         val time = Formatter.getDateTimeFromTS(limitTS)
         eventsDB.updateEventRepetitionLimit(limitTS - time.hourOfDay, eventId)
-
+        context.cancelNotification(eventId)
+        context.cancelPendingIntent(eventId)
         if (config.caldavSync) {
             val event = eventsDB.getEventWithId(eventId)
             if (event?.getCalDAVCalendarId() != 0) {


### PR DESCRIPTION
Canceling notification and pending intent while deleting event with future occurrences should fix the non existing event notification show issue. Updating or other functionalities should not also get affected with this change