### PR TITLE
Rename CATEGORY_COLOR field in ics-export (fix #1396)

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/Constants.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/Constants.kt
@@ -125,7 +125,8 @@ const val RECURRENCE_ID = "RECURRENCE-ID"
 const val SEQUENCE = "SEQUENCE"
 
 // this tag isn't a standard ICS tag, but there's no official way of adding a category color in an ics file
-const val CATEGORY_COLOR = "CATEGORY_COLOR:"
+const val CATEGORY_COLOR = "X-SMT-CATEGORY-COLOR:"
+const val CATEGORY_COLOR_LEGACY = "CATEGORY_COLOR:"
 
 const val DISPLAY = "DISPLAY"
 const val EMAIL = "EMAIL"

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/IcsImporter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/IcsImporter.kt
@@ -118,6 +118,11 @@ class IcsImporter(val activity: SimpleActivity) {
                         if (!value.startsWith("-")) {
                             curReminderTriggerMinutes *= -1
                         }
+                    } else if (line.startsWith(CATEGORY_COLOR_LEGACY)) {
+                        val color = line.substring(CATEGORY_COLOR_LEGACY.length)
+                        if (color.trimStart('-').areDigitsOnly()) {
+                            curCategoryColor = Integer.parseInt(color)
+                        }
                     } else if (line.startsWith(CATEGORY_COLOR)) {
                         val color = line.substring(CATEGORY_COLOR.length)
                         if (color.trimStart('-').areDigitsOnly()) {


### PR DESCRIPTION
I've renamed the `CATEGORY_COLOR` property to `X-SMT-CATEGORY-COLOR` in order to follow RFC 5545.
Older exports can still be imported. 