### PR TITLE
Fix sorting in month view to startTS -> endTS -> title

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/models/MonthViewEvent.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/models/MonthViewEvent.kt
@@ -1,4 +1,4 @@
 package com.simplemobiletools.calendar.pro.models
 
-data class MonthViewEvent(val id: Long, val title: String, val startTS: Long, val color: Int, val startDayIndex: Int, val daysCnt: Int, val originalStartDayIndex: Int,
+data class MonthViewEvent(val id: Long, val title: String, val startTS: Long, val endTS: Long, val color: Int, val startDayIndex: Int, val daysCnt: Int, val originalStartDayIndex: Int,
                           val isAllDay: Boolean, val isPastEvent: Boolean)

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/views/MonthView.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/views/MonthView.kt
@@ -121,14 +121,14 @@ class MonthView(context: Context, attrs: AttributeSet, defStyle: Int) : View(con
                 val daysCnt = getEventLastingDaysCount(event)
                 val validDayEvent = isDayValid(event, day.code)
                 if ((lastEvent == null || lastEvent.startDayIndex + daysCnt <= day.indexOnMonthView) && !validDayEvent) {
-                    val monthViewEvent = MonthViewEvent(event.id!!, event.title, event.startTS, event.color, day.indexOnMonthView,
+                    val monthViewEvent = MonthViewEvent(event.id!!, event.title, event.startTS, event.endTS, event.color, day.indexOnMonthView,
                         daysCnt, day.indexOnMonthView, event.getIsAllDay(), event.isPastEvent)
                     allEvents.add(monthViewEvent)
                 }
             }
         }
 
-        allEvents = allEvents.asSequence().sortedWith(compareBy({ -it.daysCnt }, { !it.isAllDay }, { it.startTS }, { it.startDayIndex }, { it.title }))
+        allEvents = allEvents.asSequence().sortedWith(compareBy({ -it.daysCnt }, { !it.isAllDay }, { it.startTS }, { it.endTS }, { it.startDayIndex }, { it.title }))
             .toMutableList() as ArrayList<MonthViewEvent>
     }
 


### PR DESCRIPTION
**Notes**
- fix sorting in month view to prioritise the start time stamp `startTS`, then the end time stamp  `endTS` before the `title`
- should fix this [issue](https://github.com/SimpleMobileTools/Simple-Calendar/issues/1410)
<img src="https://user-images.githubusercontent.com/25648077/129238693-c59e5995-1c70-423f-97c9-74de6b0824e4.gif" alt="Screenshot" width="302">
