### PR TITLE
[Translation FR] Correct 1 string => "afficher" should be "affichage"

### DIFF
--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -177,7 +177,7 @@
     <string name="replace_description_with_location">Remplacer la description de l\’événement par l\’emplacement</string>
     <string name="delete_all_events">Supprimer tous les événements</string>
     <string name="delete_all_events_confirmation">Êtes-vous certain de vouloir supprimer tous les événements ? Les types d\’événements et vos autres paramètres ne seront pas modifiés.</string>
-    <string name="show_a_grid">Afficher une grille</string>
+    <string name="show_a_grid">Affichage en grille</string>
     <string name="loop_reminders">Répéter les rappels jusqu\’à ce qu\’ils soient rejetés</string>
     <string name="dim_past_events">Estomper les événements passés</string>
     <string name="events">Événements</string>


### PR DESCRIPTION
Correct string is : <string name="show_a_grid">Affichage en grille</string>