### PR TITLE
fix week view missing some days on slider change

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/fragments/WeekFragmentsHolder.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/fragments/WeekFragmentsHolder.kt
@@ -60,11 +60,40 @@ class WeekFragmentsHolder : MyFragmentHolder(), WeekFragmentListener {
     }
 
     private fun setupFragment() {
+        addHours()
+        setupWeeklyViewPager()
+
+        weekHolder!!.week_view_hours_scrollview.setOnTouchListener { view, motionEvent -> true }
+
+        weekHolder!!.week_view_seekbar.apply {
+            progress = context?.config?.weeklyViewDays ?: 7
+            max = MAX_SEEKBAR_VALUE
+
+            onSeekBarChangeListener {
+                if (it == 0) {
+                    progress = 1
+                }
+
+                updateWeeklyViewDays(progress)
+            }
+        }
+
+        // avoid seekbar width changing if the days count changes to 1, 10 etc
+        weekHolder!!.week_view_days_count.onGlobalLayout {
+            weekHolder!!.week_view_seekbar.layoutParams.width = weekHolder!!.week_view_seekbar.width
+            (weekHolder!!.week_view_seekbar.layoutParams as RelativeLayout.LayoutParams).removeRule(RelativeLayout.START_OF)
+        }
+
+        updateDaysCount(context?.config?.weeklyViewDays ?: 7)
+        updateActionBarTitle()
+    }
+
+    private fun setupWeeklyViewPager(){
         val weekTSs = getWeekTimestamps(currentWeekTS)
         val weeklyAdapter = MyWeekPagerAdapter(activity!!.supportFragmentManager, weekTSs, this)
-        addHours()
 
         defaultWeeklyPage = weekTSs.size / 2
+
         viewPager!!.apply {
             adapter = weeklyAdapter
             addOnPageChangeListener(object : ViewPager.OnPageChangeListener {
@@ -92,29 +121,6 @@ class WeekFragmentsHolder : MyFragmentHolder(), WeekFragmentListener {
                 weeklyAdapter.updateScrollY(viewPager!!.currentItem, y)
             }
         })
-        weekHolder!!.week_view_hours_scrollview.setOnTouchListener { view, motionEvent -> true }
-
-        weekHolder!!.week_view_seekbar.apply {
-            progress = context?.config?.weeklyViewDays ?: 7
-            max = MAX_SEEKBAR_VALUE
-
-            onSeekBarChangeListener {
-                if (it == 0) {
-                    progress = 1
-                }
-
-                updateWeeklyViewDays(progress)
-            }
-        }
-
-        // avoid seekbar width changing if the days count changes to 1, 10 etc
-        weekHolder!!.week_view_days_count.onGlobalLayout {
-            weekHolder!!.week_view_seekbar.layoutParams.width = weekHolder!!.week_view_seekbar.width
-            (weekHolder!!.week_view_seekbar.layoutParams as RelativeLayout.LayoutParams).removeRule(RelativeLayout.START_OF)
-        }
-
-        updateDaysCount(context?.config?.weeklyViewDays ?: 7)
-        updateActionBarTitle()
     }
 
     private fun addHours(textColor: Int = context!!.config.textColor) {
@@ -205,6 +211,7 @@ class WeekFragmentsHolder : MyFragmentHolder(), WeekFragmentListener {
     private fun updateWeeklyViewDays(days: Int) {
         context!!.config.weeklyViewDays = days
         updateDaysCount(days)
+        setupWeeklyViewPager()
     }
 
     private fun updateDaysCount(cnt: Int) {


### PR DESCRIPTION
**Notes**
- fix week view missing some days on days count slider change
- reset the view pager to recalculate the week time stamps to get an accurate number of weeks
-  addresses a part of [this issue](https://github.com/SimpleMobileTools/Simple-Calendar/issues/1434)

**Reproduced Bug**
<figure >
<img src="https://user-images.githubusercontent.com/25648077/129657940-64121dfb-8ae3-4d41-a2a2-218a7de3a1ce.gif" alt="Reproduced Bug"  width="302" >
<figcaption align = "center">Bug screenshot (observe the days on top are incorrect when you swipe after changing the days count)</figcaption>
</figure>
<br>
<br>
<br>

**Fix**

<figure>
<img src="https://user-images.githubusercontent.com/25648077/129657895-145bf388-27fa-4561-a05b-10fd348e5e95.gif" alt="week view slider fix"  width="302">
<figcaption align = "center">Screenshot of the bug fixed (now the  days on top are correct)</figcaption>
</figure>
