### PR TITLE
Add bottom divider at the monthly view 

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/views/MonthView.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/views/MonthView.kt
@@ -204,6 +204,7 @@ class MonthView(context: Context, attrs: AttributeSet, defStyle: Int) : View(con
         for (i in 0 until ROW_COUNT) {
             canvas.drawLine(0f, i * dayHeight + weekDaysLetterHeight, canvas.width.toFloat(), i * dayHeight + weekDaysLetterHeight, gridPaint)
         }
+        canvas.drawLine(0f, canvas.height.toFloat(), canvas.width.toFloat(), canvas.height.toFloat(), gridPaint)
     }
 
     private fun addWeekDayLetters(canvas: Canvas) {


### PR DESCRIPTION
**Notes**
- show a bottom divider at the monthly view with bottom quick event type fiiltering and monthly view grid enabled
- should address this [issue](https://github.com/SimpleMobileTools/Simple-Calendar/issues/1452)

**Screenshot**
<img src="https://user-images.githubusercontent.com/25648077/130369342-19396a89-6992-4cf7-a82d-3ba7d227604b.png" alt="Screenshot" width="302">

