### PR TITLE
 update event types filter when events are imported

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/activities/MainActivity.kt
@@ -515,6 +515,7 @@ class MainActivity : SimpleActivity(), RefreshRecyclerViewListener {
                 if (result != ImportResult.IMPORT_FAIL) {
                     runOnUiThread {
                         updateViewPager()
+                        setupQuickFilter()
                     }
                 }
             }
@@ -536,6 +537,7 @@ class MainActivity : SimpleActivity(), RefreshRecyclerViewListener {
                                     it > 0 -> {
                                         toast(R.string.birthdays_added)
                                         updateViewPager()
+                                        setupQuickFilter()
                                     }
                                     it == -1 -> toast(R.string.no_new_birthdays)
                                     else -> toast(R.string.no_birthdays)
@@ -565,6 +567,7 @@ class MainActivity : SimpleActivity(), RefreshRecyclerViewListener {
                                     it > 0 -> {
                                         toast(R.string.anniversaries_added)
                                         updateViewPager()
+                                        setupQuickFilter()
                                     }
                                     it == -1 -> toast(R.string.no_new_anniversaries)
                                     else -> toast(R.string.no_anniversaries)
@@ -899,6 +902,7 @@ class MainActivity : SimpleActivity(), RefreshRecyclerViewListener {
             if (it) {
                 runOnUiThread {
                     updateViewPager()
+                    setupQuickFilter()
                 }
             }
         }


### PR DESCRIPTION
**Notes**
- update event types filter when events are imported (from ics, holidays birthdays and anniversaries)

**Screenshot of issue**
<figure>
<img src="https://user-images.githubusercontent.com/25648077/130370176-cffb7edb-4a12-46d2-b3ef-f3be17991f7f.gif" alt="Screenshot of issue" width="302">
<figcaption align = "center">Adding new holidays does to update the quick filter</figcaption>
</figure>

<br>
<br>
<br>
<br>

**Screenshot of fix**
<figure>
<img src="https://user-images.githubusercontent.com/25648077/130370195-2d0203be-f2e0-4a9a-aa0d-950cb0731ac8.gif" alt="Screenshot of issue" width="302">
<figcaption align = "center">Adding new holidays now updates the quick filter</figcaption>
</figure>


