### PR TITLE
fix updating event type colors for caldav events

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/CalDAVHelper.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/CalDAVHelper.kt
@@ -14,10 +14,10 @@ import com.simplemobiletools.calendar.pro.models.*
 import com.simplemobiletools.calendar.pro.objects.States.isUpdatingCalDAV
 import com.simplemobiletools.commons.extensions.*
 import com.simplemobiletools.commons.helpers.*
-import org.joda.time.DateTimeZone
-import org.joda.time.format.DateTimeFormat
 import java.util.*
 import kotlin.collections.ArrayList
+import org.joda.time.DateTimeZone
+import org.joda.time.format.DateTimeFormat
 
 @SuppressLint("MissingPermission")
 class CalDAVHelper(val context: Context) {
@@ -37,6 +37,7 @@ class CalDAVHelper(val context: Context) {
                     title = calendar.displayName
                     caldavDisplayName = calendar.displayName
                     caldavEmail = calendar.accountName
+                    color = calendar.color
                     eventsHelper.insertOrUpdateEventTypeSync(this)
                 }
 
@@ -65,7 +66,8 @@ class CalDAVHelper(val context: Context) {
             Calendars.ACCOUNT_TYPE,
             Calendars.OWNER_ACCOUNT,
             Calendars.CALENDAR_COLOR,
-            Calendars.CALENDAR_ACCESS_LEVEL)
+            Calendars.CALENDAR_ACCESS_LEVEL
+        )
 
         val selection = if (ids.trim().isNotEmpty()) "${Calendars._ID} IN ($ids)" else null
         context.queryCursor(uri, projection, selection, showErrors = showToasts) { cursor ->
@@ -87,33 +89,15 @@ class CalDAVHelper(val context: Context) {
     fun updateCalDAVCalendar(eventType: EventType) {
         val uri = Calendars.CONTENT_URI
         val newUri = ContentUris.withAppendedId(uri, eventType.caldavCalendarId.toLong())
-        val projection = arrayOf(
-            Calendars.CALENDAR_COLOR_KEY,
-            Calendars.CALENDAR_COLOR,
-            Calendars.CALENDAR_DISPLAY_NAME
-        )
-
-        context.queryCursor(newUri, projection) { cursor ->
-            val properColorKey = cursor.getIntValue(Calendars.CALENDAR_COLOR_KEY)
-            val properColor = cursor.getIntValue(Calendars.CALENDAR_COLOR)
-            val displayName = cursor.getStringValue(Calendars.CALENDAR_DISPLAY_NAME)
-            if (eventType.color != properColor || displayName != eventType.title) {
-                val values = fillCalendarContentValues(properColorKey, displayName)
-                try {
-                    context.contentResolver.update(newUri, values, null, null)
-                    eventType.color = properColor
-                    eventType.title = displayName
-                    context.eventTypesDB.insertOrUpdate(eventType)
-                } catch (e: IllegalArgumentException) {
-                }
-            }
+        val values = ContentValues().apply {
+            put(Calendars.CALENDAR_COLOR, eventType.color)
+            put(Calendars.CALENDAR_DISPLAY_NAME, eventType.title)
         }
-    }
-
-    private fun fillCalendarContentValues(colorKey: Int, title: String): ContentValues {
-        return ContentValues().apply {
-            put(Calendars.CALENDAR_COLOR_KEY, colorKey)
-            put(Calendars.CALENDAR_DISPLAY_NAME, title)
+        try {
+            context.contentResolver.update(newUri, values, null, null)
+            context.eventTypesDB.insertOrUpdate(eventType)
+        } catch (e: IllegalArgumentException) {
+            e.printStackTrace()
         }
     }
 
@@ -172,7 +156,7 @@ class CalDAVHelper(val context: Context) {
             Events.CALENDAR_TIME_ZONE,
             Events.DELETED,
             Events.AVAILABILITY
-            )
+        )
 
         val selection = "${Events.CALENDAR_ID} = $calendarId"
         context.queryCursor(uri, projection, selection, showErrors = showToasts) { cursor ->
@@ -209,11 +193,13 @@ class CalDAVHelper(val context: Context) {
 
             val source = "$CALDAV-$calendarId"
             val repeatRule = Parser().parseRepeatInterval(rrule, startTS)
-            val event = Event(null, startTS, endTS, title, location, description, reminder1?.minutes ?: REMINDER_OFF,
+            val event = Event(
+                null, startTS, endTS, title, location, description, reminder1?.minutes ?: REMINDER_OFF,
                 reminder2?.minutes ?: REMINDER_OFF, reminder3?.minutes ?: REMINDER_OFF, reminder1?.type
-                ?: REMINDER_NOTIFICATION, reminder2?.type ?: REMINDER_NOTIFICATION, reminder3?.type
-                ?: REMINDER_NOTIFICATION, repeatRule.repeatInterval, repeatRule.repeatRule,
-                repeatRule.repeatLimit, ArrayList(), attendees, importId, eventTimeZone, allDay, eventTypeId, source = source, availability = availability)
+                    ?: REMINDER_NOTIFICATION, reminder2?.type ?: REMINDER_NOTIFICATION, reminder3?.type
+                    ?: REMINDER_NOTIFICATION, repeatRule.repeatInterval, repeatRule.repeatRule,
+                repeatRule.repeatLimit, ArrayList(), attendees, importId, eventTimeZone, allDay, eventTypeId, source = source, availability = availability
+            )
 
             if (event.getIsAllDay()) {
                 event.startTS = Formatter.getShiftedImportTimestamp(event.startTS)
@@ -471,7 +457,8 @@ class CalDAVHelper(val context: Context) {
         val uri = Reminders.CONTENT_URI
         val projection = arrayOf(
             Reminders.MINUTES,
-            Reminders.METHOD)
+            Reminders.METHOD
+        )
         val selection = "${Reminders.EVENT_ID} = $eventId"
 
         context.queryCursor(uri, projection, selection) { cursor ->
@@ -494,7 +481,8 @@ class CalDAVHelper(val context: Context) {
             Attendees.ATTENDEE_NAME,
             Attendees.ATTENDEE_EMAIL,
             Attendees.ATTENDEE_STATUS,
-            Attendees.ATTENDEE_RELATIONSHIP)
+            Attendees.ATTENDEE_RELATIONSHIP
+        )
         val selection = "${Attendees.EVENT_ID} = $eventId"
         context.queryCursor(uri, projection, selection) { cursor ->
             val name = cursor.getStringValue(Attendees.ATTENDEE_NAME) ?: ""

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/models/Event.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/models/Event.kt
@@ -1,16 +1,13 @@
 package com.simplemobiletools.calendar.pro.models
 
 import androidx.collection.LongSparseArray
-import androidx.room.ColumnInfo
-import androidx.room.Entity
-import androidx.room.Index
-import androidx.room.PrimaryKey
+import androidx.room.*
 import com.simplemobiletools.calendar.pro.extensions.seconds
 import com.simplemobiletools.calendar.pro.helpers.*
 import com.simplemobiletools.commons.extensions.addBitIf
+import java.io.Serializable
 import org.joda.time.DateTime
 import org.joda.time.DateTimeZone
-import java.io.Serializable
 
 @Entity(tableName = "events", indices = [(Index(value = ["id"], unique = true))])
 data class Event(
@@ -38,8 +35,10 @@ data class Event(
     @ColumnInfo(name = "parent_id") var parentId: Long = 0,
     @ColumnInfo(name = "last_updated") var lastUpdated: Long = 0L,
     @ColumnInfo(name = "source") var source: String = SOURCE_SIMPLE_CALENDAR,
-    @ColumnInfo(name = "availability") var availability: Int = 0)
-    : Serializable {
+    @ColumnInfo(name = "availability") var availability: Int = 0,
+    @Ignore
+    var color: Int = 0,
+) : Serializable {
 
     companion object {
         private const val serialVersionUID = -32456795132345616L
@@ -195,8 +194,6 @@ data class Event(
         set(isPastEvent) {
             flags = flags.addBitIf(isPastEvent, FLAG_IS_PAST_EVENT)
         }
-
-    var color: Int = 0
 
     fun getTimeZoneString(): String {
         return if (timeZone.isNotEmpty() && getAllTimeZones().map { it.zoneName }.contains(timeZone)) {


### PR DESCRIPTION
**Notes**
- fix updating event type colors for caldav events 
- add `color` field to `Event` class so it's included in the computation for hashCode, hashCode is used to determine when to update events
- should address this [issue](https://github.com/SimpleMobileTools/Simple-Calendar/issues/1260) 

https://user-images.githubusercontent.com/25648077/135476903-561841b2-0db6-4382-9a6b-c7097396fd30.mp4



