### PR TITLE
Escape fr loc string correctly

### DIFF
--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -136,7 +136,7 @@
 
     <!-- Weekly view -->
     <string name="week">Semaine</string>
-    <string name="start_week_with_current_day">Démarrer la semaine à la date d'aujourd'hui</string>
+    <string name="start_week_with_current_day">Démarrer la semaine à la date d\'aujourd\'hui</string>
 
     <!-- Event types -->
     <string name="event_types">Type d\’événement</string>


### PR DESCRIPTION
When building with latest master I get the following error message

> .gradle/caches/transforms-3/026348292c2524c04a3effddde17e05c/transformed/jetified-Simple-Commons-ea206806fc/res/values-fr/values-fr.xml: Failed to flatten XML for resource 'start_week_with_current_day' with error: Invalid unicode escape sequence in string
"{str}"
.gradle/caches/transforms-3/026348292c2524c04a3effddde17e05c/transformed/jetified-Simple-Commons-ea206806fc/res/values-fr/values-fr.xml: string/start_week_with_current_day does not contain a valid string resource.

> Execution failed for task ':app:mergeDebugResources'.
> A failure occurred while executing com.android.build.gradle.internal.res.ResourceCompilerRunnable
   > Resource compilation failed. Check logs for details.