### PR TITLE
[Proposal] Visibility of time indicator

### DIFF
--- a/app/src/main/res/layout/weekly_view_day_column.xml
+++ b/app/src/main/res/layout/weekly_view_day_column.xml
@@ -3,4 +3,24 @@
     android:id="@+id/week_column"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:layout_weight="1" />
+    android:layout_weight="1">
+
+    <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_weight="1">
+    </RelativeLayout>
+
+    <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_weight="1">
+    </RelativeLayout>
+
+    <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_weight="1">
+    </RelativeLayout>
+
+</RelativeLayout>


### PR DESCRIPTION
This PR isn't intended to be merged, but purely an investigation how to approach the problem.

I'd love to have the current time indicator in front of the event backgrounds. I'm mostly in the weekly view with 1day as a scale, when the indicator complete disappears for any active events. (It's currently 8pm in my local)

<img width="358" alt="2021-10-12 at 19 51 48@2x" src="https://user-images.githubusercontent.com/91447896/137059053-ff76a6db-c803-4513-9a99-3c0b5439b162.png">

But even with a different scale, the indicator isn't really helpful IMO. If you would have multiple events on the surrounding days, the indicator would be hidden again.

<img width="356" alt="2021-10-12 at 19 53 12@2x" src="https://user-images.githubusercontent.com/91447896/137059069-c5a78b1d-f840-49e4-af5c-b39e5b4cf91e.png">

As part of the PR I explored a different view hierarchy to get the indicator visible, but still hidden behind the actual event title. 

<img width="358" alt="2021-10-12 at 19 49 43@2x" src="https://user-images.githubusercontent.com/91447896/137059095-8ba46835-0ac8-4970-a8b8-219bb8a5b33a.png">

As said, the PR isn't fully functional, but outlines a potential approach.

My question would be, if you are interested in such a change to make the indicator better accessible? If so, what do you think about the general approach in this PR?

If you are fine in general, I'd take this further to a fully functional change.

