### PR TITLE
fix weekly view highlighting weekends incorrectly

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/fragments/WeekFragment.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/fragments/WeekFragment.kt
@@ -217,7 +217,7 @@ class WeekFragment : Fragment(), WeeklyCalendar {
                 resources.getColor(R.color.theme_light_text_color)
             } else if (todayCode == dayCode) {
                 primaryColor
-            } else if (highlightWeekends && isWeekend(curDay.dayOfWeek - 1, config.isSundayFirst)) {
+            } else if (highlightWeekends && isWeekend(i, config.isSundayFirst)) {
                 resources.getColor(R.color.red_text)
             } else {
                 config.textColor


### PR DESCRIPTION
**Notes**
- fix weekly view highlighting weekends incorrectly
- should address this [issue](https://github.com/SimpleMobileTools/Simple-Calendar/issues/1507)