### PR TITLE
Fix: Wrong days highlighted in week view

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/fragments/WeekFragment.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/fragments/WeekFragment.kt
@@ -217,7 +217,7 @@ class WeekFragment : Fragment(), WeeklyCalendar {
                 resources.getColor(R.color.theme_light_text_color)
             } else if (todayCode == dayCode) {
                 primaryColor
-            } else if (highlightWeekends && isWeekend(curDay.dayOfWeek, !config.isSundayFirst)) {
+            } else if (highlightWeekends && isWeekend(curDay.dayOfWeek, true)) {
                 config.highlightWeekendsColor
             } else {
                 config.textColor

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/fragments/WeekFragment.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/fragments/WeekFragment.kt
@@ -217,7 +217,7 @@ class WeekFragment : Fragment(), WeeklyCalendar {
                 resources.getColor(R.color.theme_light_text_color)
             } else if (todayCode == dayCode) {
                 primaryColor
-            } else if (highlightWeekends && isWeekend(i, config.isSundayFirst)) {
+            } else if (highlightWeekends && isWeekend(curDay.dayOfWeek, !config.isSundayFirst)) {
                 config.highlightWeekendsColor
             } else {
                 config.textColor


### PR DESCRIPTION
If `startWeekWithCurrentDay` was enabled, `highlightWeekends` lead to the wrong days beeing
highlighted, because the column index passed to `isWeekend` didn't correspond to the day of week
anymore. This change fixes this by using `curDay.dayOfWeek` instead.