### PR TITLE
Fixed showing unnecessary back arrow

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/activities/MainActivity.kt
@@ -829,6 +829,7 @@ class MainActivity : SimpleActivity(), RefreshRecyclerViewListener {
 
         fragment.arguments = bundle
         supportFragmentManager.beginTransaction().add(R.id.fragments_holder, fragment).commitNow()
+        supportActionBar?.setDisplayHomeAsUpEnabled(false)
     }
 
     fun openMonthFromYearly(dateTime: DateTime) {


### PR DESCRIPTION
Hi,

I've found the bug that the back arrow is not hidden after changing the view when previously we were in a view opened directly from another (like in a daily view opened by clicking on a date in monthly view). The back arrow was misleading since it was closing the app instead of going back in the history.

I've fixed it by hiding the back arrow, since the logic of changing views doesn't keep the history of what has been opened.

**Before:**

https://user-images.githubusercontent.com/85929121/146652648-19a29d49-89d3-4005-b667-d33960c070c4.mp4

**After:**

https://user-images.githubusercontent.com/85929121/146652650-bb9bb776-1aed-47a9-a4c5-eb84c8691eed.mp4