### PR TITLE
Fixed crash while creating monthly widget

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/extensions/Context.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/extensions/Context.kt
@@ -437,26 +437,29 @@ fun Context.addDayNumber(rawTextColor: Int, day: DayMonthly, linearLayout: Linea
     if (!day.isThisMonth)
         textColor = textColor.adjustAlpha(LOWER_ALPHA)
 
-    (View.inflate(applicationContext, R.layout.day_monthly_number_view, null) as TextView).apply {
-        setTextColor(textColor)
-        text = day.value.toString()
-        gravity = Gravity.TOP or Gravity.CENTER_HORIZONTAL
+    View.inflate(applicationContext, R.layout.day_monthly_number_view, null).apply {
         layoutParams = LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT)
         linearLayout.addView(this)
 
-        if (day.isToday) {
-            val primaryColor = getAdjustedPrimaryColor()
-            setTextColor(primaryColor.getContrastColor())
-            if (dayLabelHeight == 0) {
-                onGlobalLayout {
-                    val height = this@apply.height
-                    if (height > 0) {
-                        callback(height)
-                        addTodaysBackground(this, resources, height, primaryColor)
+        findViewById<TextView>(R.id.day_monthly_number_id).apply {
+            setTextColor(textColor)
+            text = day.value.toString()
+            gravity = Gravity.TOP or Gravity.CENTER_HORIZONTAL
+
+            if (day.isToday) {
+                val primaryColor = getAdjustedPrimaryColor()
+                setTextColor(primaryColor.getContrastColor())
+                if (dayLabelHeight == 0) {
+                    onGlobalLayout {
+                        val height = this@apply.height
+                        if (height > 0) {
+                            callback(height)
+                            addTodaysBackground(this, resources, height, primaryColor)
+                        }
                     }
+                } else {
+                    addTodaysBackground(this, resources, dayLabelHeight, primaryColor)
                 }
-            } else {
-                addTodaysBackground(this, resources, dayLabelHeight, primaryColor)
             }
         }
     }


### PR DESCRIPTION
Hi,

I've found that it was impossible to create a monthly widget. Here is a fix for it.

BTW. These new colors (for past events and next month events) on monthly widget are too bright, it would look better if they would be the same as in the app.

**Before:**

https://user-images.githubusercontent.com/85929121/155964464-59d74cc9-ac70-44c5-96b5-271b7ebb00e2.mp4

**After:**

https://user-images.githubusercontent.com/85929121/155964479-07c3bd00-7d79-4b43-ba35-f3387061c913.mp4
