### PR TITLE
Use TextClock at widgets for showing current date

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/MyWidgetDateProvider.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/MyWidgetDateProvider.kt
@@ -12,7 +12,6 @@ import com.simplemobiletools.calendar.pro.activities.SplashActivity
 import com.simplemobiletools.calendar.pro.extensions.config
 import com.simplemobiletools.commons.extensions.applyColorFilter
 import com.simplemobiletools.commons.extensions.getLaunchIntent
-import com.simplemobiletools.commons.extensions.setText
 
 class MyWidgetDateProvider : AppWidgetProvider() {
     private val OPEN_APP_INTENT_ID = 1
@@ -21,11 +20,8 @@ class MyWidgetDateProvider : AppWidgetProvider() {
         appWidgetManager.getAppWidgetIds(getComponentName(context)).forEach {
             RemoteViews(context.packageName, R.layout.widget_date).apply {
                 applyColorFilter(R.id.widget_date_background, context.config.widgetBgColor)
-                setText(R.id.widget_date_label, Formatter.getTodayDayNumber())
-                setText(R.id.widget_month_label, Formatter.getCurrentMonthShort())
-
-                setTextColor(R.id.widget_date_label, context.config.widgetTextColor)
-                setTextColor(R.id.widget_month_label, context.config.widgetTextColor)
+                setTextColor(R.id.widget_date, context.config.widgetTextColor)
+                setTextColor(R.id.widget_month, context.config.widgetTextColor)
 
                 setupAppOpenIntent(context, this)
                 appWidgetManager.updateAppWidget(it, this)

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/MyWidgetListProvider.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/MyWidgetListProvider.kt
@@ -16,7 +16,10 @@ import com.simplemobiletools.calendar.pro.extensions.launchNewEventIntent
 import com.simplemobiletools.calendar.pro.extensions.widgetsDB
 import com.simplemobiletools.calendar.pro.services.WidgetService
 import com.simplemobiletools.calendar.pro.services.WidgetServiceEmpty
-import com.simplemobiletools.commons.extensions.*
+import com.simplemobiletools.commons.extensions.applyColorFilter
+import com.simplemobiletools.commons.extensions.getColoredBitmap
+import com.simplemobiletools.commons.extensions.getLaunchIntent
+import com.simplemobiletools.commons.extensions.setTextSize
 import com.simplemobiletools.commons.helpers.ensureBackgroundThread
 import org.joda.time.DateTime
 
@@ -45,9 +48,6 @@ class MyWidgetListProvider : AppWidgetProvider() {
                     setTextColor(R.id.widget_event_list_today, textColor)
                     setTextSize(R.id.widget_event_list_today, fontSize)
                 }
-
-                val todayText = Formatter.getLongestDate(getNowSeconds())
-                views.setText(R.id.widget_event_list_today, todayText)
 
                 views.setImageViewBitmap(R.id.widget_event_new_event, context.resources.getColoredBitmap(R.drawable.ic_plus_vector, textColor))
                 setupIntent(context, views, NEW_EVENT, R.id.widget_event_new_event)

--- a/app/src/main/res/layout/widget_date.xml
+++ b/app/src/main/res/layout/widget_date.xml
@@ -9,30 +9,37 @@
         android:id="@+id/widget_date_background"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_alignStart="@+id/widget_date_label"
-        android:layout_alignTop="@+id/widget_date_label"
-        android:layout_alignEnd="@+id/widget_date_label"
-        android:layout_alignBottom="@+id/widget_month_label"
-        android:src="@drawable/widget_round_background" />
+        android:layout_alignStart="@+id/widget_date"
+        android:layout_alignTop="@+id/widget_date"
+        android:layout_alignEnd="@+id/widget_date"
+        android:layout_alignBottom="@+id/widget_month"
+        android:src="@drawable/widget_round_background"
+        tools:ignore="ContentDescription" />
 
-    <TextView
-        android:id="@+id/widget_date_label"
+    <TextClock
+        android:id="@+id/widget_date"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:format12Hour="d"
+        android:format24Hour="d"
         android:gravity="center"
+        android:includeFontPadding="false"
         android:paddingTop="@dimen/medium_margin"
         android:textColor="@color/md_grey_white"
         android:textSize="26sp"
         tools:text="1" />
 
-    <TextView
-        android:id="@+id/widget_month_label"
+    <TextClock
+        android:id="@+id/widget_month"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_below="@+id/widget_date_label"
-        android:layout_alignStart="@+id/widget_date_label"
-        android:layout_alignEnd="@+id/widget_date_label"
+        android:layout_below="@+id/widget_date"
+        android:layout_alignStart="@+id/widget_date"
+        android:layout_alignEnd="@+id/widget_date"
+        android:format12Hour="MMM"
+        android:format24Hour="MMM"
         android:gravity="center"
+        android:includeFontPadding="false"
         android:paddingBottom="@dimen/medium_margin"
         android:textColor="@color/md_grey_white"
         android:textSize="@dimen/bigger_text_size"

--- a/app/src/main/res/layout/widget_event_list.xml
+++ b/app/src/main/res/layout/widget_event_list.xml
@@ -15,7 +15,7 @@
         android:layout_alignParentBottom="true"
         android:src="@drawable/widget_round_background" />
 
-    <TextView
+    <TextClock
         android:id="@+id/widget_event_list_today"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -23,12 +23,16 @@
         android:layout_alignBottom="@+id/widget_event_go_to_today"
         android:layout_toStartOf="@+id/widget_event_go_to_today"
         android:ellipsize="end"
+        android:format12Hour="MMM d yyyy (EEEE)"
+        android:format24Hour="MMM d yyyy (EEEE)"
         android:gravity="center_vertical"
+        android:includeFontPadding="false"
         android:maxLines="1"
         android:paddingStart="@dimen/medium_margin"
+        android:paddingTop="@dimen/medium_margin"
         android:paddingEnd="@dimen/medium_margin"
         android:textSize="@dimen/normal_text_size"
-        tools:text="July 18" />
+        tools:text="May 25 2022 (Wednesday)" />
 
     <ImageView
         android:id="@+id/widget_event_go_to_today"


### PR DESCRIPTION
Both event lists and current date widgets now use the TextClock view.
 
**Before:**

https://user-images.githubusercontent.com/36371707/170241161-91096625-219e-46ba-bab5-173cb81bc1af.mp4

**After:**

https://user-images.githubusercontent.com/36371707/170241446-04dc6c18-4f6d-48d1-af2a-bd19a07ff28f.mp4


