### PR TITLE
Allow creating tasks as well using the event list widget btn

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -194,6 +194,11 @@
             android:exported="false"
             android:theme="@style/Theme.Transparent" />
 
+        <activity
+            android:name=".activities.EventTypePickerActivity"
+            android:exported="false"
+            android:theme="@style/Theme.Transparent" />
+
         <receiver
             android:name=".helpers.MyWidgetMonthlyProvider"
             android:exported="true"

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/activities/EventTypePickerActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/activities/EventTypePickerActivity.kt
@@ -1,0 +1,35 @@
+package com.simplemobiletools.calendar.pro.activities
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.simplemobiletools.calendar.pro.R
+import com.simplemobiletools.calendar.pro.extensions.launchNewEventIntent
+import com.simplemobiletools.calendar.pro.extensions.launchNewTaskIntent
+import com.simplemobiletools.commons.dialogs.RadioGroupDialog
+import com.simplemobiletools.commons.models.RadioItem
+
+class EventTypePickerActivity : AppCompatActivity() {
+    private val TYPE_EVENT = 0
+    private val TYPE_TASK = 1
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val items = arrayListOf(
+            RadioItem(TYPE_EVENT, getString(R.string.event)),
+            RadioItem(TYPE_TASK, getString(R.string.task))
+        )
+        RadioGroupDialog(this, items = items, cancelCallback = { dialogCancelled() }) {
+            val checkedId = it as Int
+            if (checkedId == TYPE_EVENT) {
+                launchNewEventIntent()
+            } else if (checkedId == TYPE_TASK) {
+                launchNewTaskIntent()
+            }
+            finish()
+        }
+    }
+
+    private fun dialogCancelled() {
+        finish()
+    }
+}

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/extensions/Context.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/extensions/Context.kt
@@ -377,7 +377,7 @@ fun Context.launchNewTaskIntent(dayCode: String = Formatter.getTodayCode(), allo
     }
 }
 
-fun Context.launchNewEventActivity() {
+fun Context.launchNewEventOrTaskActivity() {
     if (config.allowCreatingTasks) {
         Intent(this, EventTypePickerActivity::class.java).apply {
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/extensions/Context.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/extensions/Context.kt
@@ -25,6 +25,7 @@ import androidx.core.app.NotificationCompat
 import androidx.print.PrintHelper
 import com.simplemobiletools.calendar.pro.R
 import com.simplemobiletools.calendar.pro.activities.EventActivity
+import com.simplemobiletools.calendar.pro.activities.EventTypePickerActivity
 import com.simplemobiletools.calendar.pro.activities.SnoozeReminderActivity
 import com.simplemobiletools.calendar.pro.activities.TaskActivity
 import com.simplemobiletools.calendar.pro.databases.EventsDatabase
@@ -373,6 +374,17 @@ fun Context.launchNewTaskIntent(dayCode: String = Formatter.getTodayCode(), allo
         putExtra(NEW_EVENT_START_TS, getNewEventTimestampFromCode(dayCode, allowChangingDay))
         addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         startActivity(this)
+    }
+}
+
+fun Context.launchNewEventActivity() {
+    if (config.allowCreatingTasks) {
+        Intent(this, EventTypePickerActivity::class.java).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            startActivity(this)
+        }
+    } else {
+        launchNewEventIntent()
     }
 }
 

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/MyWidgetListProvider.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/MyWidgetListProvider.kt
@@ -9,6 +9,7 @@ import android.content.Intent
 import android.net.Uri
 import android.widget.RemoteViews
 import com.simplemobiletools.calendar.pro.R
+import com.simplemobiletools.calendar.pro.activities.EventTypePickerActivity
 import com.simplemobiletools.calendar.pro.activities.SplashActivity
 import com.simplemobiletools.calendar.pro.extensions.config
 import com.simplemobiletools.calendar.pro.extensions.getWidgetFontSize
@@ -86,7 +87,7 @@ class MyWidgetListProvider : AppWidgetProvider() {
 
     override fun onReceive(context: Context, intent: Intent) {
         when (intent.action) {
-            NEW_EVENT -> context.launchNewEventIntent()
+            NEW_EVENT -> launchNewEventActivity(context)
             LAUNCH_CAL -> launchCalenderInDefaultView(context)
             GO_TO_TODAY -> goToToday(context)
             else -> super.onReceive(context, intent)
@@ -99,6 +100,17 @@ class MyWidgetListProvider : AppWidgetProvider() {
             appWidgetIds?.forEach {
                 context?.widgetsDB?.deleteWidgetId(it)
             }
+        }
+    }
+
+    private fun launchNewEventActivity(context: Context) {
+        if (context.config.allowCreatingTasks) {
+            Intent(context, EventTypePickerActivity::class.java).apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                context.startActivity(this)
+            }
+        } else {
+            context.launchNewEventIntent()
         }
     }
 

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/MyWidgetListProvider.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/MyWidgetListProvider.kt
@@ -9,11 +9,10 @@ import android.content.Intent
 import android.net.Uri
 import android.widget.RemoteViews
 import com.simplemobiletools.calendar.pro.R
-import com.simplemobiletools.calendar.pro.activities.EventTypePickerActivity
 import com.simplemobiletools.calendar.pro.activities.SplashActivity
 import com.simplemobiletools.calendar.pro.extensions.config
 import com.simplemobiletools.calendar.pro.extensions.getWidgetFontSize
-import com.simplemobiletools.calendar.pro.extensions.launchNewEventIntent
+import com.simplemobiletools.calendar.pro.extensions.launchNewEventActivity
 import com.simplemobiletools.calendar.pro.extensions.widgetsDB
 import com.simplemobiletools.calendar.pro.services.WidgetService
 import com.simplemobiletools.calendar.pro.services.WidgetServiceEmpty
@@ -87,7 +86,7 @@ class MyWidgetListProvider : AppWidgetProvider() {
 
     override fun onReceive(context: Context, intent: Intent) {
         when (intent.action) {
-            NEW_EVENT -> launchNewEventActivity(context)
+            NEW_EVENT -> context.launchNewEventActivity()
             LAUNCH_CAL -> launchCalenderInDefaultView(context)
             GO_TO_TODAY -> goToToday(context)
             else -> super.onReceive(context, intent)
@@ -100,17 +99,6 @@ class MyWidgetListProvider : AppWidgetProvider() {
             appWidgetIds?.forEach {
                 context?.widgetsDB?.deleteWidgetId(it)
             }
-        }
-    }
-
-    private fun launchNewEventActivity(context: Context) {
-        if (context.config.allowCreatingTasks) {
-            Intent(context, EventTypePickerActivity::class.java).apply {
-                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                context.startActivity(this)
-            }
-        } else {
-            context.launchNewEventIntent()
         }
     }
 

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/MyWidgetListProvider.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/MyWidgetListProvider.kt
@@ -12,7 +12,7 @@ import com.simplemobiletools.calendar.pro.R
 import com.simplemobiletools.calendar.pro.activities.SplashActivity
 import com.simplemobiletools.calendar.pro.extensions.config
 import com.simplemobiletools.calendar.pro.extensions.getWidgetFontSize
-import com.simplemobiletools.calendar.pro.extensions.launchNewEventActivity
+import com.simplemobiletools.calendar.pro.extensions.launchNewEventOrTaskActivity
 import com.simplemobiletools.calendar.pro.extensions.widgetsDB
 import com.simplemobiletools.calendar.pro.services.WidgetService
 import com.simplemobiletools.calendar.pro.services.WidgetServiceEmpty
@@ -86,7 +86,7 @@ class MyWidgetListProvider : AppWidgetProvider() {
 
     override fun onReceive(context: Context, intent: Intent) {
         when (intent.action) {
-            NEW_EVENT -> context.launchNewEventActivity()
+            NEW_EVENT -> context.launchNewEventOrTaskActivity()
             LAUNCH_CAL -> launchCalenderInDefaultView(context)
             GO_TO_TODAY -> goToToday(context)
             else -> super.onReceive(context, intent)

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/MyWidgetMonthlyProvider.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/MyWidgetMonthlyProvider.kt
@@ -14,7 +14,7 @@ import com.simplemobiletools.calendar.pro.R
 import com.simplemobiletools.calendar.pro.activities.SplashActivity
 import com.simplemobiletools.calendar.pro.extensions.config
 import com.simplemobiletools.calendar.pro.extensions.getWidgetFontSize
-import com.simplemobiletools.calendar.pro.extensions.launchNewEventActivity
+import com.simplemobiletools.calendar.pro.extensions.launchNewEventOrTaskActivity
 import com.simplemobiletools.calendar.pro.interfaces.MonthlyCalendar
 import com.simplemobiletools.calendar.pro.models.DayMonthly
 import com.simplemobiletools.calendar.pro.models.Event
@@ -73,7 +73,7 @@ class MyWidgetMonthlyProvider : AppWidgetProvider() {
             PREV -> getPrevMonth(context)
             NEXT -> getNextMonth(context)
             GO_TO_TODAY -> goToToday(context)
-            NEW_EVENT -> context.launchNewEventActivity()
+            NEW_EVENT -> context.launchNewEventOrTaskActivity()
             else -> super.onReceive(context, intent)
         }
     }

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/MyWidgetMonthlyProvider.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/MyWidgetMonthlyProvider.kt
@@ -14,7 +14,7 @@ import com.simplemobiletools.calendar.pro.R
 import com.simplemobiletools.calendar.pro.activities.SplashActivity
 import com.simplemobiletools.calendar.pro.extensions.config
 import com.simplemobiletools.calendar.pro.extensions.getWidgetFontSize
-import com.simplemobiletools.calendar.pro.extensions.launchNewEventIntent
+import com.simplemobiletools.calendar.pro.extensions.launchNewEventActivity
 import com.simplemobiletools.calendar.pro.interfaces.MonthlyCalendar
 import com.simplemobiletools.calendar.pro.models.DayMonthly
 import com.simplemobiletools.calendar.pro.models.Event
@@ -73,7 +73,7 @@ class MyWidgetMonthlyProvider : AppWidgetProvider() {
             PREV -> getPrevMonth(context)
             NEXT -> getNextMonth(context)
             GO_TO_TODAY -> goToToday(context)
-            NEW_EVENT -> context.launchNewEventIntent()
+            NEW_EVENT -> context.launchNewEventActivity()
             else -> super.onReceive(context, intent)
         }
     }


### PR DESCRIPTION
This PR addresses https://github.com/SimpleMobileTools/Simple-Calendar/issues/1665

Users can now create tasks as well as events using the plus button:

<img src="https://user-images.githubusercontent.com/36371707/174485970-4f0d94f1-fecb-4290-b4dd-4847fb4f8b5a.gif" width=264 /> 