### PR TITLE
bugfix multi week event not showing in next week

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/fragments/WeekFragment.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/fragments/WeekFragment.kt
@@ -537,7 +537,7 @@ class WeekFragment : Fragment(), WeeklyCalendar {
         }
 
         dayevents@ for (event in events) {
-            val startDateTime = Formatter.getDateTimeFromTS(event.startTS)
+            val startDateTime = Formatter.getDateTimeFromTS(if (weekTimestamp > event.startTS) weekTimestamp else event.startTS)
             val startDayCode = Formatter.getDayCodeFromDateTime(startDateTime)
             val endDateTime = Formatter.getDateTimeFromTS(event.endTS)
             val endDayCode = Formatter.getDayCodeFromDateTime(endDateTime)


### PR DESCRIPTION
## Description
- As reported in issue #1799 , events that span more than one week were not visible in the last week.

