### PR TITLE
Correct behaviour when fallback to other languages

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,6 +22,7 @@ android {
         multiDexEnabled true
         setProperty("archivesBaseName", "calendar")
         vectorDrawables.useSupportLibrary = true
+        resConfigs "en", "ar", "az", "be", "bg", "bn", "br", "ca", "cs", "da", "de", "el", "eo", "es", "et", "eu", "fi", "fr", "gl", "hi-rIN", "hr", "hu", "in", "it", "iw", "ja", "ko", "lt", "lv", "ml", "nb-rNO", "nl", "pl", "pt", "pt-rBR", "ro", "ru", "sk", "sv", "th", "tr", "uk", "zh-rCN", "zh-rHK", "zh-rTW"
     }
 
     signingConfigs {


### PR DESCRIPTION
Currently, when the primary system language isn't supported by this app, it directly fallbacks to English, instead of continue checking the rest of the languages configured in the system's language settings. This can be solved by adding the resConfigs option, that prevent libraries adding strings to the build in languages the app doesn't support.