### PR TITLE
All-day event timezone fixes

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/activities/EventActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/activities/EventActivity.kt
@@ -224,9 +224,14 @@ class EventActivity : SimpleActivity() {
         updateTextColors(event_scrollview)
         updateIconColors()
         refreshMenuItems()
-        event_time_zone_divider.beVisibleIf(config.allowChangingTimeZones)
-        event_time_zone_image.beVisibleIf(config.allowChangingTimeZones)
-        event_time_zone.beVisibleIf(config.allowChangingTimeZones)
+        showOrHideTimeZone()
+    }
+
+    private fun showOrHideTimeZone() {
+        val allowChangingTimeZones = config.allowChangingTimeZones && !event_all_day.isChecked
+        event_time_zone_divider.beVisibleIf(allowChangingTimeZones)
+        event_time_zone_image.beVisibleIf(allowChangingTimeZones)
+        event_time_zone.beVisibleIf(allowChangingTimeZones)
     }
 
     private fun refreshMenuItems() {
@@ -998,6 +1003,9 @@ class EventActivity : SimpleActivity() {
         hideKeyboard()
         event_start_time.beGoneIf(isChecked)
         event_end_time.beGoneIf(isChecked)
+        mEvent.timeZone = if (isChecked) DateTimeZone.UTC.id else DateTimeZone.getDefault().id
+        updateTimeZoneText()
+        showOrHideTimeZone()
         resetTime()
     }
 
@@ -1149,7 +1157,11 @@ class EventActivity : SimpleActivity() {
             reminder3Type = mReminder3Type
             repeatInterval = mRepeatInterval
             importId = newImportId
-            timeZone = if (mEvent.timeZone.isEmpty()) TimeZone.getDefault().id else timeZone
+            timeZone = when {
+                mIsAllDayEvent -> DateTimeZone.UTC.id
+                timeZone.isEmpty() -> DateTimeZone.getDefault().id
+                else -> timeZone
+            }
             flags = mEvent.flags.addBitIf(event_all_day.isChecked, FLAG_ALL_DAY)
             repeatLimit = if (repeatInterval == 0) 0 else mRepeatLimit
             repeatRule = mRepeatRule

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/CalDAVHelper.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/CalDAVHelper.kt
@@ -228,8 +228,8 @@ class CalDAVHelper(val context: Context) {
             val event = Event(
                 null, startTS, endTS, title, location, description, reminder1?.minutes ?: REMINDER_OFF,
                 reminder2?.minutes ?: REMINDER_OFF, reminder3?.minutes ?: REMINDER_OFF, reminder1?.type
-                    ?: REMINDER_NOTIFICATION, reminder2?.type ?: REMINDER_NOTIFICATION, reminder3?.type
-                    ?: REMINDER_NOTIFICATION, repeatRule.repeatInterval, repeatRule.repeatRule,
+                ?: REMINDER_NOTIFICATION, reminder2?.type ?: REMINDER_NOTIFICATION, reminder3?.type
+                ?: REMINDER_NOTIFICATION, repeatRule.repeatInterval, repeatRule.repeatRule,
                 repeatRule.repeatLimit, ArrayList(), attendees, importId, eventTimeZone, allDay, eventTypeId, source = source, availability = availability
             )
 

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/IcsImporter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/IcsImporter.kt
@@ -212,6 +212,7 @@ class IcsImporter(val activity: SimpleActivity) {
 
                         val eventType = eventTypes.firstOrNull { it.id == curEventTypeId }
                         val source = if (calDAVCalendarId == 0 || eventType?.isSyncedEventType() == false) SOURCE_IMPORTED_ICS else "$CALDAV-$calDAVCalendarId"
+                        val isAllDay = curFlags and FLAG_ALL_DAY != 0
                         val event = Event(
                             null,
                             curStart,
@@ -231,7 +232,7 @@ class IcsImporter(val activity: SimpleActivity) {
                             curRepeatExceptions,
                             "",
                             curImportId,
-                            DateTimeZone.getDefault().id,
+                            if (isAllDay) DateTimeZone.UTC.id else DateTimeZone.getDefault().id,
                             curFlags,
                             curEventTypeId,
                             0,
@@ -240,7 +241,7 @@ class IcsImporter(val activity: SimpleActivity) {
                             curAvailability
                         )
 
-                        if (event.getIsAllDay() && curEnd > curStart) {
+                        if (isAllDay && curEnd > curStart) {
                             event.endTS -= DAY
 
                             // fix some glitches related to daylight saving shifts

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/Parser.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/Parser.kt
@@ -102,7 +102,7 @@ class Parser {
             parseLongFormat(edited, value.endsWith("Z"))
         } else {
             val dateTimeFormat = DateTimeFormat.forPattern("yyyyMMdd")
-            dateTimeFormat.parseDateTime(edited).withHourOfDay(5).seconds()
+            dateTimeFormat.parseDateTime(edited).withHourOfDay(13).seconds()
         }
     }
 


### PR DESCRIPTION
Closes issues https://github.com/SimpleMobileTools/Simple-Calendar/issues/1539, https://github.com/SimpleMobileTools/Simple-Calendar/issues/1480, https://github.com/SimpleMobileTools/Simple-Calendar/issues/1521

### Notes: 
- All-day events now use UTC timezone
- It's no longer possible to change the timezone when creating or editing an all-day event (until All day checkbox is unticked)
- When importing an all-day event from an ICS file, the start and end timestamps now are offset by hour  13 instead of 5 (as per [this line](https://github.com/SimpleMobileTools/Simple-Calendar/blob/4aa78bfb0bc858d3941458e5b269f770c7b664f3/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/Formatter.kt#L138)), this fixes the issue in #1521. The bug was likely introduced in commit https://github.com/SimpleMobileTools/Simple-Calendar/commit/37c86400d4dfc80138a9a8f6eefae0097e191a9e
- #1256 and #1249 are related issues but not addressed in this PR