### PR TITLE
Properly handle all-day event timezone

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/extensions/Event.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/extensions/Event.kt
@@ -1,0 +1,30 @@
+package com.simplemobiletools.calendar.pro.extensions
+
+import com.simplemobiletools.calendar.pro.helpers.Formatter
+import com.simplemobiletools.calendar.pro.helpers.TWELVE_HOURS
+import com.simplemobiletools.calendar.pro.models.Event
+import org.joda.time.DateTimeZone
+
+/** Shifts all-day events to local timezone such that the event starts and ends on the same time as in UTC */
+fun Event.toLocalAllDayEvent() {
+    require(this.getIsAllDay()) { "Must be an all day event!" }
+
+    timeZone = DateTimeZone.getDefault().id
+    startTS = Formatter.getShiftedLocalTS(startTS)
+    endTS = Formatter.getShiftedLocalTS(endTS)
+    if (endTS > startTS) {
+        endTS -= TWELVE_HOURS
+    }
+}
+
+/** Shifts all-day events to UTC such that the event starts on the same time in UTC too */
+fun Event.toUtcAllDayEvent() {
+    require(getIsAllDay()) { "Must be an all day event!" }
+
+    if (endTS >= startTS) {
+        endTS += TWELVE_HOURS
+    }
+    timeZone = DateTimeZone.UTC.id
+    startTS = Formatter.getShiftedUtcTS(startTS)
+    endTS = Formatter.getShiftedUtcTS(endTS)
+}

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/extensions/Event.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/extensions/Event.kt
@@ -5,7 +5,7 @@ import com.simplemobiletools.calendar.pro.helpers.TWELVE_HOURS
 import com.simplemobiletools.calendar.pro.models.Event
 import org.joda.time.DateTimeZone
 
-/** Shifts all-day events to local timezone such that the event starts and ends on the same time as in UTC */
+// shifts all-day events to local timezone such that the event starts and ends on the same time as in UTC
 fun Event.toLocalAllDayEvent() {
     require(this.getIsAllDay()) { "Must be an all day event!" }
 
@@ -17,13 +17,14 @@ fun Event.toLocalAllDayEvent() {
     }
 }
 
-/** Shifts all-day events to UTC such that the event starts on the same time in UTC too */
+// shifts all-day events to UTC such that the event starts on the same time in UTC too
 fun Event.toUtcAllDayEvent() {
     require(getIsAllDay()) { "Must be an all day event!" }
 
     if (endTS >= startTS) {
         endTS += TWELVE_HOURS
     }
+
     timeZone = DateTimeZone.UTC.id
     startTS = Formatter.getShiftedUtcTS(startTS)
     endTS = Formatter.getShiftedUtcTS(endTS)

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/Constants.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/Constants.kt
@@ -53,6 +53,7 @@ const val DEFAULT_START_TIME_CURRENT_TIME = -2
 const val TYPE_EVENT = 0
 const val TYPE_TASK = 1
 
+const val TWELVE_HOURS = 43200
 const val DAY = 86400
 const val WEEK = 604800
 const val MONTH = 2592001    // exact value not taken into account, Joda is used for adding months and years

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/Formatter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/Formatter.kt
@@ -135,7 +135,11 @@ object Formatter {
 
     fun getUTCDayCodeFromTS(ts: Long) = getUTCDateTimeFromTS(ts).toString(DAYCODE_PATTERN)
 
-    fun getShiftedImportTimestamp(ts: Long) = getUTCDateTimeFromTS(ts).withTime(13, 0, 0, 0).withZoneRetainFields(DateTimeZone.getDefault()).seconds()
-
     fun getYearFromDayCode(dayCode: String) = getDateTimeFromCode(dayCode).toString(YEAR_PATTERN)
+
+    fun getShiftedTS(dateTime: DateTime, toZone: DateTimeZone) = dateTime.withTimeAtStartOfDay().withZoneRetainFields(toZone).seconds()
+
+    fun getShiftedLocalTS(ts: Long) = getShiftedTS(dateTime = getUTCDateTimeFromTS(ts), toZone = DateTimeZone.getDefault())
+
+    fun getShiftedUtcTS(ts: Long) = getShiftedTS(dateTime = getDateTimeFromTS(ts), toZone = DateTimeZone.UTC)
 }

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/IcsExporter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/IcsExporter.kt
@@ -4,7 +4,9 @@ import android.provider.CalendarContract.Events
 import com.simplemobiletools.calendar.pro.R
 import com.simplemobiletools.calendar.pro.extensions.calDAVHelper
 import com.simplemobiletools.calendar.pro.extensions.eventTypesDB
-import com.simplemobiletools.calendar.pro.helpers.IcsExporter.ExportResult.*
+import com.simplemobiletools.calendar.pro.helpers.IcsExporter.ExportResult.EXPORT_FAIL
+import com.simplemobiletools.calendar.pro.helpers.IcsExporter.ExportResult.EXPORT_OK
+import com.simplemobiletools.calendar.pro.helpers.IcsExporter.ExportResult.EXPORT_PARTIAL
 import com.simplemobiletools.calendar.pro.models.CalDAVCalendar
 import com.simplemobiletools.calendar.pro.models.Event
 import com.simplemobiletools.commons.activities.BaseSimpleActivity
@@ -61,7 +63,7 @@ class IcsExporter {
 
                     if (event.getIsAllDay()) {
                         out.writeLn("$DTSTART;$VALUE=$DATE:${Formatter.getDayCodeFromTS(event.startTS)}")
-                        out.writeLn("$DTEND;$VALUE=$DATE:${Formatter.getDayCodeFromTS(event.endTS + DAY)}")
+                        out.writeLn("$DTEND;$VALUE=$DATE:${Formatter.getDayCodeFromTS(event.endTS + TWELVE_HOURS)}")
                     } else {
                         event.startTS.let { out.writeLn("$DTSTART:${Formatter.getExportedTime(it * 1000L)}") }
                         event.endTS.let { out.writeLn("$DTEND:${Formatter.getExportedTime(it * 1000L)}") }

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/IcsImporter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/IcsImporter.kt
@@ -232,7 +232,7 @@ class IcsImporter(val activity: SimpleActivity) {
                             curRepeatExceptions,
                             "",
                             curImportId,
-                            if (isAllDay) DateTimeZone.UTC.id else DateTimeZone.getDefault().id,
+                            DateTimeZone.getDefault().id,
                             curFlags,
                             curEventTypeId,
                             0,
@@ -242,8 +242,7 @@ class IcsImporter(val activity: SimpleActivity) {
                         )
 
                         if (isAllDay && curEnd > curStart) {
-                            event.endTS -= DAY
-
+                            event.endTS -= TWELVE_HOURS
                             // fix some glitches related to daylight saving shifts
                             if (event.startTS - event.endTS == HOUR_SECONDS.toLong()) {
                                 event.endTS += HOUR_SECONDS

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/Parser.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/Parser.kt
@@ -10,6 +10,7 @@ import com.simplemobiletools.commons.extensions.areDigitsOnly
 import com.simplemobiletools.commons.helpers.*
 import org.joda.time.DateTimeZone
 import org.joda.time.format.DateTimeFormat
+import kotlin.math.floor
 
 class Parser {
     // from RRULE:FREQ=DAILY;COUNT=5 to Daily, 5x...
@@ -101,8 +102,9 @@ class Parser {
         return if (edited.length == 14) {
             parseLongFormat(edited, value.endsWith("Z"))
         } else {
-            val dateTimeFormat = DateTimeFormat.forPattern("yyyyMMdd")
-            dateTimeFormat.parseDateTime(edited).withHourOfDay(13).seconds()
+            val dateTimeFormat = DateTimeFormat.forPattern("yyyyMMdd").withZoneUTC()
+            val dateTime = dateTimeFormat.parseDateTime(edited)
+            Formatter.getShiftedTS(dateTime = dateTime, toZone = DateTimeZone.getDefault())
         }
     }
 
@@ -227,12 +229,12 @@ class Parser {
         var hours = 0
         var remainder = minutes
         if (remainder >= DAY_MINUTES) {
-            days = Math.floor((remainder / DAY_MINUTES).toDouble()).toInt()
+            days = floor((remainder / DAY_MINUTES).toDouble()).toInt()
             remainder -= days * DAY_MINUTES
         }
 
         if (remainder >= 60) {
-            hours = Math.floor((remainder / 60).toDouble()).toInt()
+            hours = floor((remainder / 60).toDouble()).toInt()
             remainder -= hours * 60
         }
 


### PR DESCRIPTION
Fixes issues like all-day events moving +-1 day when synchronized

Because of the way timezones are handled at the UI level, all-day events are shifted to the local timezone so that they are displayed on the proper date and shifted back to UTC when exporting them.

_shifted as in [withZoneRetainFields](https://joda-time.sourceforge.net/apidocs/org/joda/time/DateTime.html#withZoneRetainFields(org.joda.time.DateTimeZone))_ 