### PR TITLE
Set the "Manual" flag in the caldav sync, only if it is triggered by the user and he is notified via toasts

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/activities/MainActivity.kt
@@ -134,7 +134,7 @@ class MainActivity : SimpleActivity(), RefreshRecyclerViewListener {
         }
 
         swipe_refresh_layout.setOnRefreshListener {
-            refreshCalDAVCalendars(false)
+            refreshCalDAVCalendars(true)
         }
 
         checkIsViewIntent()

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/extensions/Context.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/extensions/Context.kt
@@ -603,7 +603,10 @@ fun Context.refreshCalDAVCalendars(ids: String, showToasts: Boolean) {
 
     Bundle().apply {
         putBoolean(ContentResolver.SYNC_EXTRAS_EXPEDITED, true)
-        putBoolean(ContentResolver.SYNC_EXTRAS_MANUAL, true)
+        if (showToasts) {
+            // Assume this is a manual synchronisation when we showToasts to the user (swipe_refresh, MainMenu->refresh_caldav_calendars, ...)
+            putBoolean(ContentResolver.SYNC_EXTRAS_MANUAL, true)
+        }
         accounts.forEach {
             ContentResolver.requestSync(it, uri.authority, this)
         }


### PR DESCRIPTION
As described in ticket #1847, we should not always send the `SYNC_EXTRAS_MANUAL` flag to DAVx5, instead we should only set it for user-initiated synchronisations. Otherwise, the forced synchronisations will lead to many error messages in DAVx5 when no permitted WLAN is available.

Assume that the caldav sync is `MANUAL` when we show toasts to the user as in:
- ✔️ MainActivity -> swipe reload
- ✔️ MainActivity -> MenuItem "refresh_caldav_calendars"
- ✔️ SettingsActivity -> changes in caldav calendar picker
- ❌ CalDavHelper -> insert, delete, edit caldav events
- ❌ CalDavHelper -> scheduleCalDAVSync() with alarm service every 2h