### PR TITLE
Always show single day all-day events at the top

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/fragments/WeekFragment.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/fragments/WeekFragment.kt
@@ -700,7 +700,7 @@ class WeekFragment : Fragment(), WeeklyCalendar {
     private fun shouldAddEventOnTopBar(isAllDay: Boolean, startDayCode: String, endDayCode: String): Boolean {
         val spansMultipleDays = startDayCode != endDayCode
         val isSingleDayAllDayEvent = isAllDay && !spansMultipleDays
-        return isSingleDayAllDayEvent || spansMultipleDays && config.showMidnightSpanningEventsAtTop
+        return isSingleDayAllDayEvent || (spansMultipleDays && config.showMidnightSpanningEventsAtTop)
     }
 
     @SuppressLint("NewApi")

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/fragments/WeekFragment.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/fragments/WeekFragment.kt
@@ -454,7 +454,7 @@ class WeekFragment : Fragment(), WeeklyCalendar {
             val endDayCode = Formatter.getDayCodeFromDateTime(endDateTime)
             val isAllDay = event.getIsAllDay()
 
-            if ((isAllDay || (startDayCode != endDayCode)) && config.showMidnightSpanningEventsAtTop) {
+            if (shouldAddEventOnTopBar(isAllDay, startDayCode, endDayCode)) {
                 continue
             }
 
@@ -543,7 +543,8 @@ class WeekFragment : Fragment(), WeeklyCalendar {
             val startDayCode = Formatter.getDayCodeFromDateTime(startDateTime)
             val endDateTime = Formatter.getDateTimeFromTS(event.endTS)
             val endDayCode = Formatter.getDayCodeFromDateTime(endDateTime)
-            if ((event.getIsAllDay() || (startDayCode != endDayCode)) && config.showMidnightSpanningEventsAtTop) {
+
+            if (shouldAddEventOnTopBar(event.getIsAllDay(), startDayCode, endDayCode)) {
                 addAllDayEvent(event)
             } else {
                 var currentDateTime = startDateTime
@@ -694,6 +695,12 @@ class WeekFragment : Fragment(), WeeklyCalendar {
                 listener?.updateHoursTopMargin(mView.week_top_holder.height)
             }
         }
+    }
+
+    private fun shouldAddEventOnTopBar(isAllDay: Boolean, startDayCode: String, endDayCode: String): Boolean {
+        val spansMultipleDays = startDayCode != endDayCode
+        val isSingleDayAllDayEvent = isAllDay && !spansMultipleDays
+        return isSingleDayAllDayEvent || spansMultipleDays && config.showMidnightSpanningEventsAtTop
     }
 
     @SuppressLint("NewApi")


### PR DESCRIPTION
**Before:**
The following events were shown at the top as per the user preference:
 - Any event spanning multiple days 
 - All all-day events
 
**Now:**
 - Any event spanning multiple days (all-day or not) is still shown at the top as per the user preference
 - Any all-day event lasting only one day is now always shown at the top **regardless** of user preference

<img src="https://user-images.githubusercontent.com/36371707/203851144-653c5859-8f88-4b96-affd-8431659afc85.png" width=200 />
