### PR TITLE
Fixed color change in event editor

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/activities/EventActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/activities/EventActivity.kt
@@ -995,6 +995,7 @@ class EventActivity : SimpleActivity() {
             if (eventType != null) {
                 runOnUiThread {
                     event_type.text = eventType.title
+                    updateEventColorInfo(eventType.color)
                 }
             }
         }


### PR DESCRIPTION
Hi,

Color in the editor UI wasn't updating after changing the event type, but it was saving correctly. I fixed it, so now it also displays correctly.

**Before:**

https://github.com/SimpleMobileTools/Simple-Calendar/assets/85929121/4d6b2269-d902-4546-8667-c48be8ee2e60

**After:**

https://github.com/SimpleMobileTools/Simple-Calendar/assets/85929121/4fcf512f-5acd-4df9-991d-de1b43473872



