### PR TITLE
Fixed recurring event repetition exception issue

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/CalDAVHelper.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/CalDAVHelper.kt
@@ -264,9 +264,6 @@ class CalDAVHelper(val context: Context) {
                     parentEvent.addRepetitionException(originalDayCode)
                     eventsHelper.insertEvent(parentEvent, addToCalDAV = false, showToasts = false)
 
-                    event.parentId = parentEvent.id!!
-                    event.addRepetitionException(originalDayCode)
-                    eventsHelper.insertEvent(event, addToCalDAV = false, showToasts = false)
                     return@queryCursorInlined
                 }
             }


### PR DESCRIPTION
Resolves:

- https://github.com/SimpleMobileTools/Simple-Calendar/issues/1698

When a repetition exception is added to the event which itself is an exception to the repetition, it is not shown in the calendar.

Successfully tested this with DAVx5 and Nextcloud.