### PR TITLE
Properly handle `Update all occurrences` option

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/activities/EventActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/activities/EventActivity.kt
@@ -1386,7 +1386,19 @@ class EventActivity : SimpleActivity() {
                 }
                 EDIT_ALL_OCCURRENCES -> {
                     ensureBackgroundThread {
-                        eventsHelper.addEventRepeatLimit(mEvent.id!!, mEventOccurrenceTS)
+                        // Shift the start and end times of the first (original) event based on the changes made
+                        val originalEvent = eventsDB.getEventWithId(mEvent.id!!) ?: return@ensureBackgroundThread
+                        val originalStartTS = originalEvent.startTS
+                        val originalEndTS = originalEvent.endTS
+                        val oldStartTS = mOriginalStartTS
+                        val oldEndTS = mOriginalEndTS
+
+                        mEvent.apply {
+                            val startTSDelta = oldStartTS - startTS
+                            val endTSDelta = oldEndTS - endTS
+                            startTS = originalStartTS - startTSDelta
+                            endTS = originalEndTS - endTSDelta
+                        }
                         eventsHelper.updateEvent(mEvent, updateAtCalDAV = true, showToasts = true) {
                             finish()
                         }

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/activities/TaskActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/activities/TaskActivity.kt
@@ -502,7 +502,16 @@ class TaskActivity : SimpleActivity() {
                 }
                 EDIT_ALL_OCCURRENCES -> {
                     ensureBackgroundThread {
-                        eventsHelper.addEventRepeatLimit(mTask.id!!, mTaskOccurrenceTS)
+                        // Shift the start and end times of the first (original) event based on the changes made
+                        val originalEvent = eventsDB.getTaskWithId(mTask.id!!) ?: return@ensureBackgroundThread
+                        val originalStartTS = originalEvent.startTS
+                        val oldStartTS = mOriginalStartTS
+
+                        mTask.apply {
+                            val startTSDelta = oldStartTS - startTS
+                            startTS = originalStartTS - startTSDelta
+                            endTS = startTS
+                        }
                         eventsHelper.updateEvent(mTask, updateAtCalDAV = false, showToasts = true) {
                             finish()
                         }


### PR DESCRIPTION
Closes https://github.com/SimpleMobileTools/Simple-Calendar/issues/981

The events were moved forward because the start and end timestamps from the repeating occurrence were saved instead of the original start and end times.

The call to `eventsHelper.addEventRepeatLimit()` was removed because I believe it was added there by mistake and the changes were overwritten anyways due to the next call to `eventsHelper.updateEvent()`. Another reason to remove it is to avoid triggering a CalDAV update which may interfere with the event update.

### Video


https://github.com/SimpleMobileTools/Simple-Calendar/assets/36371707/8ec47161-2639-4c08-9163-c3f15a145b51

