### PR TITLE
Properly handle `Update/Delete this and all future occurrences`

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/activities/EventActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/activities/EventActivity.kt
@@ -1382,6 +1382,10 @@ class EventActivity : SimpleActivity() {
                         mEvent.id = null
                         eventsHelper.apply {
                             addEventRepeatLimit(eventId, mEventOccurrenceTS)
+                            if (mEventOccurrenceTS == originalEvent.startTS) {
+                                deleteEvent(eventId, true)
+                            }
+
                             insertEvent(mEvent, addToCalDAV = true, showToasts = true) {
                                 finish()
                             }

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/activities/EventActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/activities/EventActivity.kt
@@ -1378,14 +1378,7 @@ class EventActivity : SimpleActivity() {
                     ensureBackgroundThread {
                         val eventId = mEvent.id!!
                         val originalEvent = eventsDB.getEventWithId(eventId) ?: return@ensureBackgroundThread
-                        val hasFixedRepeatCount = originalEvent.repeatLimit < 0 && mEvent.repeatLimit < 0
-                        val repeatLimitUnchanged = originalEvent.repeatLimit == mEvent.repeatLimit
-                        if (hasFixedRepeatCount && repeatLimitUnchanged) {
-                            val occurrencesSinceStart = (mEventOccurrenceTS - originalEvent.startTS) / originalEvent.repeatInterval
-                            val newRepeatLimit = mEvent.repeatLimit + occurrencesSinceStart
-                            mEvent.repeatLimit = newRepeatLimit
-                        }
-
+                        mEvent.maybeAdjustRepeatLimitCount(originalEvent, mEventOccurrenceTS)
                         mEvent.id = null
                         eventsHelper.apply {
                             addEventRepeatLimit(eventId, mEventOccurrenceTS)

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/activities/EventActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/activities/EventActivity.kt
@@ -1381,8 +1381,8 @@ class EventActivity : SimpleActivity() {
                         val hasFixedRepeatCount = originalEvent.repeatLimit < 0 && mEvent.repeatLimit < 0
                         val repeatLimitUnchanged = originalEvent.repeatLimit == mEvent.repeatLimit
                         if (hasFixedRepeatCount && repeatLimitUnchanged) {
-                            val daysSinceStart = (mEventOccurrenceTS - originalEvent.startTS) / DAY
-                            val newRepeatLimit = mEvent.repeatLimit + daysSinceStart
+                            val occurrencesSinceStart = (mEventOccurrenceTS - originalEvent.startTS) / originalEvent.repeatInterval
+                            val newRepeatLimit = mEvent.repeatLimit + occurrencesSinceStart
                             mEvent.repeatLimit = newRepeatLimit
                         }
 

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/activities/TaskActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/activities/TaskActivity.kt
@@ -489,13 +489,15 @@ class TaskActivity : SimpleActivity() {
                 }
                 EDIT_FUTURE_OCCURRENCES -> {
                     ensureBackgroundThread {
-                        eventsHelper.addEventRepeatLimit(mTask.id!!, mTaskOccurrenceTS)
-                        mTask.apply {
-                            id = null
-                        }
-
-                        eventsHelper.insertTask(mTask, showToasts = true) {
-                            finish()
+                        val taskId = mTask.id!!
+                        val originalTask = eventsDB.getTaskWithId(taskId) ?: return@ensureBackgroundThread
+                        mTask.maybeAdjustRepeatLimitCount(originalTask, mTaskOccurrenceTS)
+                        mTask.id = null
+                        eventsHelper.apply {
+                            addEventRepeatLimit(taskId, mTaskOccurrenceTS)
+                            insertTask(mTask, showToasts = true) {
+                                finish()
+                            }
                         }
                     }
                 }

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/activities/TaskActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/activities/TaskActivity.kt
@@ -495,6 +495,10 @@ class TaskActivity : SimpleActivity() {
                         mTask.id = null
                         eventsHelper.apply {
                             addEventRepeatLimit(taskId, mTaskOccurrenceTS)
+                            if (mTaskOccurrenceTS == originalTask.startTS) {
+                                deleteEvent(taskId, true)
+                            }
+
                             insertTask(mTask, showToasts = true) {
                                 finish()
                             }

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/extensions/Event.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/extensions/Event.kt
@@ -30,6 +30,7 @@ fun Event.toUtcAllDayEvent() {
     endTS = Formatter.getShiftedUtcTS(endTS)
 }
 
+// this is to make sure the repetition ends on the date set when creating the original event
 fun Event.maybeAdjustRepeatLimitCount(original: Event, occurrenceTS: Long) {
     val hasFixedRepeatCount = original.repeatLimit < 0 && repeatLimit < 0
     val repeatLimitUnchanged = original.repeatLimit == repeatLimit

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/extensions/Event.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/extensions/Event.kt
@@ -29,3 +29,13 @@ fun Event.toUtcAllDayEvent() {
     startTS = Formatter.getShiftedUtcTS(startTS)
     endTS = Formatter.getShiftedUtcTS(endTS)
 }
+
+fun Event.maybeAdjustRepeatLimitCount(original: Event, occurrenceTS: Long) {
+    val hasFixedRepeatCount = original.repeatLimit < 0 && repeatLimit < 0
+    val repeatLimitUnchanged = original.repeatLimit == repeatLimit
+    if (hasFixedRepeatCount && repeatLimitUnchanged) {
+        val occurrencesSinceStart = (occurrenceTS - original.startTS) / original.repeatInterval
+        val newRepeatLimit = repeatLimit + occurrencesSinceStart
+        this.repeatLimit = newRepeatLimit
+    }
+}

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/EventsHelper.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/EventsHelper.kt
@@ -226,7 +226,7 @@ class EventsHelper(val context: Context) {
     }
 
     fun addEventRepeatLimit(eventId: Long, occurrenceTS: Long) {
-        val event = eventsDB.getEventWithId(eventId) ?: return
+        val event = eventsDB.getEventOrTaskWithId(eventId) ?: return
         val previousOccurrenceTS = occurrenceTS - event.repeatInterval // always update repeat limit of the occurrence preceding the one being edited
         val repeatLimitDateTime = Formatter.getDateTimeFromTS(previousOccurrenceTS).withTimeAtStartOfDay()
         val repeatLimitTS = if (event.getIsAllDay()) {

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/Parser.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/Parser.kt
@@ -145,7 +145,14 @@ class Parser {
     private fun getRepeatLimitString(event: Event) = when {
         event.repeatLimit == 0L -> ""
         event.repeatLimit < 0 -> ";$COUNT=${-event.repeatLimit}"
-        else -> ";$UNTIL=${Formatter.getDayCodeFromTS(event.repeatLimit)}"
+        else -> if (event.getIsAllDay()) {
+            ";$UNTIL=${Formatter.getDayCodeFromTS(event.repeatLimit)}"
+        } else {
+            val dateTime = Formatter.getUTCDateTimeFromTS(event.repeatLimit)
+            val dayCode = dateTime.toString(Formatter.DAYCODE_PATTERN)
+            val timeCode = dateTime.toString(Formatter.TIME_PATTERN)
+            ";$UNTIL=${dayCode}T${timeCode}Z"
+        }
     }
 
     private fun getByMonth(event: Event) = when {


### PR DESCRIPTION
This PR fixes the following issues related to editing recurring events:

**Bug 1:**
 - Create a recurring event with a specific number of occurrences like 10 that starts on Jan 1
 - Edit some occurrence e.g. 5th and select "Update this and future occurrences only"
 - The edited event (5th) kept repeating 10 times instead of ending on the end date of the original event (10th Jan). This was not consistent with other calendars (except Nextcloud, seems like it's a bug there too).

**Bug 2:**
When choosing `Update/Delete this and all future occurrences`, future occurrences were deleted/updated but the selected occurrence was never deleted/updated. Only reproducible with all-day events.

**Bug 3:**
When choosing `Update this and all future occurrences`, everything was updated properly but the event was duplicated on the date of the selection. Only reproducible with all-day events.

**Bug 4:**
When creating a recurring event with a date as a repeat limit, the event ends a day before the date it actually should. This is only reproducible with non-all-day CalDAV events.

_Regarding the `UNTIL` DateTime timezone, [this SO answer](https://stackoverflow.com/questions/34913427/icalendar-until-rule-must-be-of-the-same-type-as-dtstart-property) and the format used by Google calendar was taken into consideration._