### PR TITLE
Ensure event type visibility when a new event or task is created

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/extensions/Context.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/extensions/Context.kt
@@ -114,11 +114,7 @@ fun Context.scheduleNextEventReminder(event: Event, showToasts: Boolean) {
     val validReminders = event.getReminders().filter { it.type == REMINDER_NOTIFICATION }
     if (validReminders.isEmpty()) {
         if (showToasts) {
-            if (config.displayEventTypes.contains(event.eventType.toString())) {
-                toast(R.string.saving)
-            } else {
-                toast(R.string.saving_filtered_out, Toast.LENGTH_LONG)
-            }
+            toast(R.string.saving)
         }
         return
     }
@@ -153,13 +149,9 @@ fun Context.scheduleEventIn(notifTS: Long, event: Event, showToasts: Boolean) {
 
     val newNotifTS = notifTS + 1000
     if (showToasts) {
-        if (config.displayEventTypes.contains(event.eventType.toString())) {
-            val secondsTillNotification = (newNotifTS - System.currentTimeMillis()) / 1000
-            val msg = String.format(getString(R.string.time_remaining), formatSecondsToTimeString(secondsTillNotification.toInt()))
-            toast(msg)
-        } else {
-            toast(R.string.saving_filtered_out, Toast.LENGTH_LONG)
-        }
+        val secondsTillNotification = (newNotifTS - System.currentTimeMillis()) / 1000
+        val msg = String.format(getString(R.string.time_remaining), formatSecondsToTimeString(secondsTillNotification.toInt()))
+        toast(msg)
     }
 
     val pendingIntent = getNotificationIntent(event)

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/CalDAVHelper.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/CalDAVHelper.kt
@@ -261,7 +261,7 @@ class CalDAVHelper(val context: Context) {
                     // add this event to the parent event's list of exceptions
                     if (!parentEvent.repetitionExceptions.contains(originalDayCode)) {
                         parentEvent.addRepetitionException(originalDayCode)
-                        eventsHelper.insertEvent(parentEvent, addToCalDAV = false, showToasts = false)
+                        eventsHelper.insertEvent(parentEvent, addToCalDAV = false, showToasts = false, enableEventType = false)
                     }
 
                     // store the event in the local db only if it is an occurrence that has been modified and not deleted
@@ -271,7 +271,7 @@ class CalDAVHelper(val context: Context) {
                             event.id = storedEventId
                         }
                         event.parentId = parentEvent.id!!
-                        eventsHelper.insertEvent(event, addToCalDAV = false, showToasts = false)
+                        eventsHelper.insertEvent(event, addToCalDAV = false, showToasts = false, enableEventType = false)
                     } else {
                         // delete the deleted exception event from local db
                         val storedEventId = context.eventsDB.getEventIdWithImportId(importId)
@@ -321,12 +321,12 @@ class CalDAVHelper(val context: Context) {
 
                 if (existingEvent.hashCode() != event.hashCode() && title.isNotEmpty()) {
                     event.id = originalEventId
-                    eventsHelper.updateEvent(event, updateAtCalDAV = false, showToasts = false)
+                    eventsHelper.updateEvent(event, updateAtCalDAV = false, showToasts = false, enableEventType = false)
                 }
             } else {
                 if (title.isNotEmpty()) {
                     importIdsMap[event.importId] = event
-                    eventsHelper.insertEvent(event, addToCalDAV = false, showToasts = false)
+                    eventsHelper.insertEvent(event, addToCalDAV = false, showToasts = false, enableEventType = false)
                 }
             }
         }

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/EventsHelper.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/helpers/EventsHelper.kt
@@ -149,16 +149,6 @@ class EventsHelper(val context: Context) {
         }
     }
 
-    private fun ensureEventTypeVisibility(event: Event, enableEventType: Boolean) {
-        if (enableEventType) {
-            val eventType = event.eventType.toString()
-            val displayEventTypes = config.displayEventTypes
-            if (!displayEventTypes.contains(eventType)) {
-                config.displayEventTypes = displayEventTypes.plus(eventType)
-            }
-        }
-    }
-
     fun insertEvents(events: ArrayList<Event>, addToCalDAV: Boolean) {
         try {
             for (event in events) {
@@ -168,7 +158,7 @@ class EventsHelper(val context: Context) {
                 }
 
                 event.id = eventsDB.insertOrUpdate(event)
-
+                ensureEventTypeVisibility(event, true)
                 context.scheduleNextEventReminder(event, false)
                 if (addToCalDAV && event.source != SOURCE_SIMPLE_CALENDAR && event.source != SOURCE_IMPORTED_ICS && config.caldavSync) {
                     context.calDAVHelper.insertCalDAVEvent(event)
@@ -188,6 +178,16 @@ class EventsHelper(val context: Context) {
             context.calDAVHelper.updateCalDAVEvent(event)
         }
         callback?.invoke()
+    }
+
+    private fun ensureEventTypeVisibility(event: Event, enableEventType: Boolean) {
+        if (enableEventType) {
+            val eventType = event.eventType.toString()
+            val displayEventTypes = config.displayEventTypes
+            if (!displayEventTypes.contains(eventType)) {
+                config.displayEventTypes = displayEventTypes.plus(eventType)
+            }
+        }
     }
 
     fun deleteAllEvents() {

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -29,7 +29,6 @@
     <string name="filter_events_by_type">تصفية الأحداث حسب النوع</string>
     <string name="please_fill_location">أدخل الإحداثية كي يتم عرضها على الخريطة</string>
     <string name="public_event_notification_text">اقتراب موعد حدث</string>
-    <string name="saving_filtered_out">تم الحفظ... ولكن تتم تصفية نوع الحدث المحدد في القائمة العلوية - تصفية</string>
     <string name="everything_filtered_out">لقد قمت بتصفية جميع أنواع الأحداث</string>
     <string name="event_color">Event color</string>
     <string name="default_calendar_color">Default calendar color</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -29,7 +29,6 @@
     <string name="filter_events_by_type">Hadisələri yazıya görə sırala</string>
     <string name="please_fill_location">Xahiş olunur məkan parametrini doldurun ki hadisədə görünsün</string>
     <string name="public_event_notification_text">Bir hadisə günü yaxınlaşır</string>
-    <string name="saving_filtered_out">Saving… But the selected event type is filtered out in the top Menu - Filter</string>
     <string name="everything_filtered_out">You have filtered out all event types</string>
     <string name="event_color">Event color</string>
     <string name="default_calendar_color">Default calendar color</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -29,7 +29,6 @@
     <string name="filter_events_by_type">Фільтраваць падзеі па тыпу</string>
     <string name="please_fill_location">Калі ласка, увядзіце месцазнаходжанне, якое будзе паказана на карце</string>
     <string name="public_event_notification_text">Набліжаецца падзея</string>
-    <string name="saving_filtered_out">Захаванне... Але абраны тып падзеі адфільтраваны ў верхнім меню - Фільтр</string>
     <string name="everything_filtered_out">You have filtered out all event types</string>
     <string name="event_color">Event color</string>
     <string name="default_calendar_color">Default calendar color</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -29,7 +29,6 @@
     <string name="filter_events_by_type">Филтриране на събитията по тип</string>
     <string name="please_fill_location">Моля попълнете местоположение за показване на картата</string>
     <string name="public_event_notification_text">Предстоящо събитие</string>
-    <string name="saving_filtered_out">Запазване…Но избраният тип събитие се филтрира от Главно Меню - Филтриране</string>
     <string name="everything_filtered_out">You have filtered out all event types</string>
     <string name="event_color">Event color</string>
     <string name="default_calendar_color">Default calendar color</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -29,7 +29,6 @@
     <string name="filter_events_by_type">টাইপের মত করে ইভেন্টগুলো ফিল্টার করুন</string>
     <string name="please_fill_location">ম্যাপে দেখানোর জন্য লোকেশন পূরণ করুন</string>
     <string name="public_event_notification_text">একটি ইভেন্ট আসছে</string>
-    <string name="saving_filtered_out">Saving… But the selected event type is filtered out in the top Menu - Filter</string>
     <string name="everything_filtered_out">You have filtered out all event types</string>
     <string name="event_color">Event color</string>
     <string name="default_calendar_color">Default calendar color</string>

--- a/app/src/main/res/values-br/strings.xml
+++ b/app/src/main/res/values-br/strings.xml
@@ -29,7 +29,6 @@
     <string name="filter_events_by_type">Silañ an darvoudoù dre rizh</string>
     <string name="please_fill_location">Please fill in a location to be shown on a map</string>
     <string name="public_event_notification_text">An event is upcoming</string>
-    <string name="saving_filtered_out">Saving… But the selected event type is filtered out in the top Menu - Filter</string>
     <string name="everything_filtered_out">You have filtered out all event types</string>
     <string name="event_color">Event color</string>
     <string name="default_calendar_color">Default calendar color</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -29,7 +29,6 @@
     <string name="filter_events_by_type">Filtra els esdeveniments per tipus</string>
     <string name="please_fill_location">Ompliu una ubicació que es mostrarà en un mapa</string>
     <string name="public_event_notification_text">S\'acosta un esdeveniment</string>
-    <string name="saving_filtered_out">S\'està desant… Però el tipus d\'esdeveniment seleccionat està filtrat al Menú superior - Filtre</string>
     <string name="everything_filtered_out">Heu filtrat tots els tipus d\'esdeveniments</string>
     <string name="event_color">Event color</string>
     <string name="default_calendar_color">Default calendar color</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -29,7 +29,6 @@
     <string name="filter_events_by_type">Filtrovat události podle typu</string>
     <string name="please_fill_location">Prosím, zadejte polohu, která má být zobrazena na mapě</string>
     <string name="public_event_notification_text">Blíží se událost</string>
-    <string name="saving_filtered_out">Ukládání… Ale vybraný typ události je odfiltrován v horním menu – Filtr</string>
     <string name="everything_filtered_out">Odfiltrovali jste všechny typy událostí</string>
     <string name="event_color">Event color</string>
     <string name="default_calendar_color">Default calendar color</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -29,7 +29,6 @@
     <string name="filter_events_by_type">Filtrer begivenheder efter type</string>
     <string name="please_fill_location">Indtast et sted der kan vises på et kort</string>
     <string name="public_event_notification_text">En begivenhed er forestående</string>
-    <string name="saving_filtered_out">Gemmer - men den valgte begivenhedstype er filtreret fra under Menu - Filter</string>
     <string name="everything_filtered_out">Du har filtreret alle typer begivenheder fra</string>
     <string name="event_color">Farve på begivenhed</string>
     <string name="default_calendar_color">Kalenderens standardfarve</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -29,7 +29,6 @@
     <string name="filter_events_by_type">Termine nach Typ filtern</string>
     <string name="please_fill_location">Bitte trage einen Ort ein, der auf einer Karte angezeigt werden soll</string>
     <string name="public_event_notification_text">Ein Termin steht an</string>
-    <string name="saving_filtered_out">Speichern … Aber der ausgewählte Termintyp wird im oberen Menü – Filter herausgefiltert</string>
     <string name="everything_filtered_out">Du hast alle Termintypen herausgefiltert</string>
     <string name="event_color">Terminfarbe</string>
     <string name="default_calendar_color">Standardkalenderfarbe</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -29,7 +29,6 @@
     <string name="filter_events_by_type">Φιλτράρισμα ανά τύπο</string>
     <string name="please_fill_location">Συμπληρώστε μια τοποθεσία που θα εμφανίζεται στο χάρτη</string>
     <string name="public_event_notification_text">Μια εκδήλωση είναι επερχόμενη</string>
-    <string name="saving_filtered_out">Αποθήκευση… Αλλά ο επιλεγμένος τύπος συμβάντος φιλτράρεται στο πάνω μενού - Φίλτρο</string>
     <string name="everything_filtered_out">Έχετε φιλτράρει όλα τα είδη συμβάντων</string>
     <string name="event_color">Χρώμα εκδήλωσης</string>
     <string name="default_calendar_color">Προεπιλεγμένο χρώμα ημερολογίου</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -29,7 +29,6 @@
     <string name="filter_events_by_type">Filter events by type</string>
     <string name="please_fill_location">Please fill in a location to be shown on a map</string>
     <string name="public_event_notification_text">An event is upcoming</string>
-    <string name="saving_filtered_out">Saving… But the selected event type is filtered out in the top Menu - Filter</string>
     <string name="everything_filtered_out">You have filtered out all event types</string>
     <string name="event_color">Event color</string>
     <string name="default_calendar_color">Default calendar color</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -29,7 +29,6 @@
     <string name="filter_events_by_type">Filtrar eventos por tipo</string>
     <string name="please_fill_location">Introduce una ubicación para mostrar en el mapa</string>
     <string name="public_event_notification_text">Hay un evento próximo</string>
-    <string name="saving_filtered_out">Guardando… Pero el tipo de evento seleccionado está excluído del filtro (Menú superior - Filtrar)</string>
     <string name="everything_filtered_out">Ha filtrado todos los tipos de cita</string>
     <string name="event_color">Event color</string>
     <string name="default_calendar_color">Default calendar color</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -29,7 +29,6 @@
     <string name="filter_events_by_type">Sündmuste filtreerimine tüübi järgi</string>
     <string name="please_fill_location">Palun kirjelda kaardil näidatav asukoht</string>
     <string name="public_event_notification_text">Sündmus on algamas</string>
-    <string name="saving_filtered_out">Salvestamine... Kuid valitud sündmuse tüüp filtreeritakse välja ülemises menüüs - Filter</string>
     <string name="everything_filtered_out">Sa oled kõik sündmuste tüübid välistanud</string>
     <string name="event_color">Event color</string>
     <string name="default_calendar_color">Default calendar color</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -29,7 +29,6 @@
     <string name="filter_events_by_type">Iragazi gertaerak motaren arabera</string>
     <string name="please_fill_location">Bete kokalekua mapan erakusteko</string>
     <string name="public_event_notification_text">Gertaera bat dator</string>
-    <string name="saving_filtered_out">Gordetzen… Baina hautatutako gertaera mota goiko menuko - Iragazkia-ren bidez iragazten da</string>
     <string name="everything_filtered_out">Gertaera mota guztiak iragazi dituzu</string>
     <string name="event_color">Event color</string>
     <string name="default_calendar_color">Default calendar color</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -29,7 +29,6 @@
     <string name="filter_events_by_type">Suodata tapahtumat tyypeittäin</string>
     <string name="please_fill_location">Täytä sijainti, joka näytetään kartalla</string>
     <string name="public_event_notification_text">Tapahtuma tulossa</string>
-    <string name="saving_filtered_out">Tallennetaan… mutta valittu tapahtumatyyppi on suodatettu pois näkyvistä Menu - Suodata-valikosta</string>
     <string name="everything_filtered_out">Olet suodattanut pois kaikki tapahtumatyypit</string>
     <string name="event_color">Event color</string>
     <string name="default_calendar_color">Default calendar color</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -29,7 +29,6 @@
     <string name="filter_events_by_type">Filtrer les évènements</string>
     <string name="please_fill_location">Veuillez renseigner un lieu pour le visualiser sur une carte</string>
     <string name="public_event_notification_text">Un évènement est à venir</string>
-    <string name="saving_filtered_out">Sauvegarde… Mais le type d\'événement sélectionné est filtré dans le Menu supérieur - Filtre</string>
     <string name="everything_filtered_out">Vous avez filtré tous les types d\'évènements</string>
     <string name="event_color">Couleur de l\'évènement</string>
     <string name="default_calendar_color">Couleur de l\'agenda par défaut</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -29,7 +29,6 @@
     <string name="filter_events_by_type">Filtrar eventos por tipo</string>
     <string name="please_fill_location">Escribe a localización para que se mostre nun mapa</string>
     <string name="public_event_notification_text">Hai un evento próximo</string>
-    <string name="saving_filtered_out">Gardando… Pero o tipo de evento seleccionado foi ocultado desde a opción de filtro no menú superior</string>
     <string name="everything_filtered_out">Filtraches todoslos tipos de eventos</string>
     <string name="event_color">Event color</string>
     <string name="default_calendar_color">Default calendar color</string>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -29,7 +29,6 @@
     <string name="filter_events_by_type">Filter events by type</string>
     <string name="please_fill_location">Please fill in a location to be shown on a map</string>
     <string name="public_event_notification_text">An event is upcoming</string>
-    <string name="saving_filtered_out">Saving… But the selected event type is filtered out in the top Menu - Filter</string>
     <string name="everything_filtered_out">You have filtered out all event types</string>
     <string name="event_color">Event color</string>
     <string name="default_calendar_color">Default calendar color</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -29,7 +29,6 @@
     <string name="filter_events_by_type">Filtriraj događaje po vrsti</string>
     <string name="please_fill_location">Upiši lokaciju za prikazivanje na karti</string>
     <string name="public_event_notification_text">Jedan događaj nadolazi</string>
-    <string name="saving_filtered_out">Spremanje … Odabrana vrsta događaja je međutim filtrirana u gornjem izborniku – Filtar</string>
     <string name="everything_filtered_out">Izdvojene su sve vrste događaja</string>
     <string name="event_color">Event color</string>
     <string name="default_calendar_color">Default calendar color</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -29,7 +29,6 @@
     <string name="filter_events_by_type">Események szűrése típus szerint</string>
     <string name="please_fill_location">Töltse ki a helyet, hogy megjelenjen a térképen</string>
     <string name="public_event_notification_text">Egy esemény következik</string>
-    <string name="saving_filtered_out">Mentés… De a kiválasztott eseménytípus ki van szűrve fent: Menü – Szűrő</string>
     <string name="everything_filtered_out">Kiszűrte az összes eseménytípust</string>
     <string name="event_color">Event color</string>
     <string name="default_calendar_color">Default calendar color</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -29,7 +29,6 @@
     <string name="filter_events_by_type">Filter acara menurut kategori</string>
     <string name="please_fill_location">Silakan isi lokasi untuk ditampilkan pada peta</string>
     <string name="public_event_notification_text">Aacara yang akan datang</string>
-    <string name="saving_filtered_out">Menyimpan… Tetapi jenis peristiwa yang dipilih disaring di Menu atas - Filter</string>
     <string name="everything_filtered_out">Anda telah menyaring semua jenis peristiwa</string>
     <string name="event_color">Event color</string>
     <string name="default_calendar_color">Default calendar color</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -29,7 +29,6 @@
     <string name="filter_events_by_type">Filtra eventi per tipologia</string>
     <string name="please_fill_location">Riempire la posizione per essere mostrata su una mappa</string>
     <string name="public_event_notification_text">Un evento è imminente</string>
-    <string name="saving_filtered_out">Salvataggio… Ma il tipo di evento selezionato viene filtrato in alto Menu - Filtro</string>
     <string name="everything_filtered_out">Sono stati filtrati tutti i tipi di evento</string>
     <string name="event_color">Colore dell\'evento</string>
     <string name="default_calendar_color">Colore predefinito del calendario</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -29,7 +29,6 @@
     <string name="filter_events_by_type">סנן אירועים לפי סוג</string>
     <string name="please_fill_location">אנא הזן מיקום להצגה במפה</string>
     <string name="public_event_notification_text">יש אירוע בקרוב</string>
-    <string name="saving_filtered_out">שומר... אבל סוג האירוע שנבחר מסונן בתפריט העליון - מסנן</string>
     <string name="everything_filtered_out">You have filtered out all event types</string>
     <string name="event_color">Event color</string>
     <string name="default_calendar_color">Default calendar color</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -29,7 +29,7 @@
     <string name="filter_events_by_type">種類による予定のフィルタリング</string>
     <string name="please_fill_location">地図上に表示する場所を入力してください</string>
     <string name="public_event_notification_text">近日中の予定</string>
-    <string name="saving_filtered_out">保存していますが、選択した予定の種類は上部メニューのフィルターで除外されています</string>v
+    v
     <string name="everything_filtered_out">すべての予定の種類を除外しました</string>
     <string name="event_color">Event color</string>
     <string name="default_calendar_color">Default calendar color</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -29,7 +29,6 @@
     <string name="filter_events_by_type">유형별 일정</string>
     <string name="please_fill_location">지도에 표시할 검색명을 입력해주세요</string>
     <string name="public_event_notification_text">다가오는 일정이 있습니다.</string>
-    <string name="saving_filtered_out">Saving… But the selected event type is filtered out in the top Menu - Filter</string>
     <string name="everything_filtered_out">You have filtered out all event types</string>
     <string name="event_color">Event color</string>
     <string name="default_calendar_color">Default calendar color</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -29,7 +29,6 @@
     <string name="filter_events_by_type">Filtruoti įvykius pagal tipą</string>
     <string name="please_fill_location">Įveskite vietą, kuri bus rodoma žemėlapyje</string>
     <string name="public_event_notification_text">Artėjantis įvykis</string>
-    <string name="saving_filtered_out">Įrašoma… Bet pasirinktas įvykių tipas yra išfiltruojamas viršutiniame Meniu – Filtras</string>
     <string name="everything_filtered_out">Jūs išfiltravote visus įvykių tipus</string>
     <string name="event_color">Event color</string>
     <string name="default_calendar_color">Default calendar color</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -29,7 +29,6 @@
     <string name="filter_events_by_type">Filtrējiet notikumus pēc tipa</string>
     <string name="please_fill_location">Lūdzu, ievadiet/norādiet atrašanās vietu, kuru parādīt kartē</string>
     <string name="public_event_notification_text">Gaidāms/Priekšāstāvošs notikums</string>
-    <string name="saving_filtered_out">Saving… But the selected event type is filtered out in the top Menu - Filter</string>
     <string name="everything_filtered_out">You have filtered out all event types</string>
     <string name="event_color">Event color</string>
     <string name="default_calendar_color">Default calendar color</string>

--- a/app/src/main/res/values-mk/strings.xml
+++ b/app/src/main/res/values-mk/strings.xml
@@ -29,7 +29,6 @@
     <string name="filter_events_by_type">Филтрирајте ги настаните по тип</string>
     <string name="please_fill_location">Ве молиме пополнете локација која ќе биде прикажана на мапа</string>
     <string name="public_event_notification_text">Настанот е претстоен</string>
-    <string name="saving_filtered_out">Спасување… Но, избраниот тип на настани се филтрира во топ Мени - Филтер</string>
     <string name="everything_filtered_out">You have filtered out all event types</string>
     <string name="event_color">Event color</string>
     <string name="default_calendar_color">Default calendar color</string>

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -29,7 +29,6 @@
     <string name="filter_events_by_type">Filter events by type</string>
     <string name="please_fill_location">Please fill in a location to be shown on a map</string>
     <string name="public_event_notification_text">An event is upcoming</string>
-    <string name="saving_filtered_out">Saving… But the selected event type is filtered out in the top Menu - Filter</string>
     <string name="everything_filtered_out">You have filtered out all event types</string>
     <string name="event_color">Event color</string>
     <string name="default_calendar_color">Default calendar color</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -29,7 +29,6 @@
     <string name="filter_events_by_type">Filtrer hendelser etter type</string>
     <string name="please_fill_location">Oppfør et sted som skal vises på et kart</string>
     <string name="public_event_notification_text">En hendelse er forestående</string>
-    <string name="saving_filtered_out">Lagrer… Men den valgte hendelsestypen er filtrert ut i Meny - Filtrer</string>
     <string name="everything_filtered_out">Du har filtrert bort alle hendelsestyper</string>
     <string name="event_color">Hendelsesfarge</string>
     <string name="default_calendar_color">Standard kalenderfarge</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -29,7 +29,6 @@
     <string name="filter_events_by_type">Afspraken op type filteren</string>
     <string name="please_fill_location">Vul de locatie in om deze op de kaart te tonen</string>
     <string name="public_event_notification_text">Afspraak aanstaande</string>
-    <string name="saving_filtered_out">Opslaan… Pas op: het gekozen afspraaktype is weggefilterd via Menu - Filteren</string>
     <string name="everything_filtered_out">Alle afspraaktypes zijn weggefilterd</string>
     <string name="event_color">Kleur voor afspraak</string>
     <string name="default_calendar_color">Standaardkleur</string>

--- a/app/src/main/res/values-nn/strings.xml
+++ b/app/src/main/res/values-nn/strings.xml
@@ -29,7 +29,6 @@
     <string name="filter_events_by_type">Sil hendingar etter slag</string>
     <string name="please_fill_location">Skriv inn ein stad</string>
     <string name="public_event_notification_text">Ei hending byrjar snart</string>
-    <string name="saving_filtered_out">Saving… But the selected event type is filtered out in the top Menu - Filter</string>
     <string name="everything_filtered_out">Du har silt ut alle hendingsslaga</string>
     <string name="event_color">Hendingslet</string>
     <string name="default_calendar_color">Forvald kalenderlet</string>

--- a/app/src/main/res/values-pa-rPK/strings.xml
+++ b/app/src/main/res/values-pa-rPK/strings.xml
@@ -59,7 +59,6 @@
     <string name="event_added">Event added successfully</string>
     <string name="please_fill_location">Please fill in a location to be shown on a map</string>
     <string name="public_event_notification_text">An event is upcoming</string>
-    <string name="saving_filtered_out">Saving… But the selected event type is filtered out in the top Menu - Filter</string>
     <string name="everything_filtered_out">You have filtered out all event types</string>
     <string name="event_color">Event color</string>
     <string name="default_calendar_color">Default calendar color</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -29,7 +29,6 @@
     <string name="filter_events_by_type">Filtruj wydarzenia według typu</string>
     <string name="please_fill_location">Wpisz lokalizację, która ma zostać pokazana na mapie</string>
     <string name="public_event_notification_text">Nadchodzi wydarzenie</string>
-    <string name="saving_filtered_out">Zapisywanie… Jednak wybrany typ wydarzenia jest odfiltrowywany w Menu -&gt; Filtruj…</string>
     <string name="everything_filtered_out">Odfiltrowałeś(-aś) wszystkie typy wydarzeń.</string>
     <string name="event_color">Kolor wydarzenia</string>
     <string name="default_calendar_color">Domyślny kolor kalendarza</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -29,7 +29,6 @@
     <string name="filter_events_by_type">Filtrar eventos por tipo</string>
     <string name="please_fill_location">Por favor, preencha um local para ser mostrado em um mapa</string>
     <string name="public_event_notification_text">Um evento está próximo</string>
-    <string name="saving_filtered_out">Salvando… Mas o tipo de evento selecionado ficou em Menu - Filtrar</string>
     <string name="everything_filtered_out">Você filtrou todos os tipos de eventos</string>
     <string name="event_color">Event color</string>
     <string name="default_calendar_color">Default calendar color</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -29,7 +29,6 @@
     <string name="filter_events_by_type">Filtrar eventos por tipo</string>
     <string name="please_fill_location">Introduza a localização a mostrar no mapa</string>
     <string name="public_event_notification_text">Está para breve um evento</string>
-    <string name="saving_filtered_out">A guardar… Mas o tipo de evento seleccionado ficou retido no filtro em Menu - Filtrar</string>
     <string name="everything_filtered_out">Você filtrou todos os tipos de eventos</string>
     <string name="event_color">Event color</string>
     <string name="default_calendar_color">Default calendar color</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -29,7 +29,6 @@
     <string name="filter_events_by_type">Filtrează evenimentele după tip</string>
     <string name="please_fill_location">Completează o locație ca să apară pe o hartă</string>
     <string name="public_event_notification_text">Se apropie un eveniment</string>
-    <string name="saving_filtered_out">Se salvează... Dar tipul de eveniment selectat este filtrat în meniul de sus - Filtru</string>
     <string name="everything_filtered_out">You have filtered out all event types</string>
     <string name="event_color">Event color</string>
     <string name="default_calendar_color">Default calendar color</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -29,7 +29,6 @@
     <string name="filter_events_by_type">Фильтровать события по типу</string>
     <string name="please_fill_location">Укажите место, которое будет показано на карте</string>
     <string name="public_event_notification_text">Предстоящее событие</string>
-    <string name="saving_filtered_out">Сохранение… Однако выбранный тип события исключён в разделе \"Фильтр\" верхнего меню</string>
     <string name="everything_filtered_out">Вы отфильтровали все типы событий</string>
     <string name="event_color">Цвет события</string>
     <string name="default_calendar_color">Цвет календаря по умолчанию</string>

--- a/app/src/main/res/values-si/strings.xml
+++ b/app/src/main/res/values-si/strings.xml
@@ -31,7 +31,6 @@
     <string name="filter_events_by_type">Filter events by type</string>
     <string name="please_fill_location">Please fill in a location to be shown on a map</string>
     <string name="public_event_notification_text">An event is upcoming</string>
-    <string name="saving_filtered_out">Saving… But the selected event type is filtered out in the top Menu - Filter</string>
     <string name="everything_filtered_out">You have filtered out all event types</string>
     <string name="event_color">Event color</string>
     <string name="default_calendar_color">Default calendar color</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -29,7 +29,6 @@
     <string name="filter_events_by_type">Filtrovať udalosti podľa typu</string>
     <string name="please_fill_location">Prosím zadajte polohu, ktorá má byť zobrazená na mape</string>
     <string name="public_event_notification_text">Blíži sa udalosť</string>
-    <string name="saving_filtered_out">Ukladá sa… Ale zvolený typ je odfiltrovaný v hornom Menu - Filtrovať</string>
     <string name="everything_filtered_out">Máte odfiltrované všetky typy udalostí</string>
     <string name="event_color">Farba udalosti</string>
     <string name="default_calendar_color">Predvolená farba kalendára</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -29,7 +29,6 @@
     <string name="filter_events_by_type">Filtriranje dogodkov po vrsti</string>
     <string name="please_fill_location">Vpišite lokacijo, ki bo prikazana na zemljevidu</string>
     <string name="public_event_notification_text">Prihaja dogodek</string>
-    <string name="saving_filtered_out">Shranjevanje… Toda izbrana vrsta dogodka je filtrirana v zgornjem meniju - Filter</string>
     <string name="everything_filtered_out">You have filtered out all event types</string>
     <string name="event_color">Event color</string>
     <string name="default_calendar_color">Default calendar color</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -29,7 +29,6 @@
     <string name="filter_events_by_type">Филтрирање догађаја по типу</string>
     <string name="please_fill_location">Попуните локацију која ће бити приказана на мапи</string>
     <string name="public_event_notification_text">Догађај се одржава</string>
-    <string name="saving_filtered_out">Чување… Али изабрани тип догађаја је филтриран у горњем менију - филтер</string>
     <string name="everything_filtered_out">You have filtered out all event types</string>
     <string name="event_color">Event color</string>
     <string name="default_calendar_color">Default calendar color</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -29,7 +29,6 @@
     <string name="filter_events_by_type">Filtrera händelser efter typ</string>
     <string name="please_fill_location">Du måste ange en plats som kan visas på en karta</string>
     <string name="public_event_notification_text">Du har en kommande händelse</string>
-    <string name="saving_filtered_out">Sparar... Men den valda händelsetypen filtreras bort i den översta menyn - Filter</string>
     <string name="everything_filtered_out">Du har filtrerat bort alla händelsetyper</string>
     <string name="event_color">Händelsens färg</string>
     <string name="default_calendar_color">Kalenderns standardfärg</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -29,7 +29,6 @@
     <string name="filter_events_by_type">Filter events by type</string>
     <string name="please_fill_location">Please fill in a location to be shown on a map</string>
     <string name="public_event_notification_text">An event is upcoming</string>
-    <string name="saving_filtered_out">Saving… But the selected event type is filtered out in the top Menu - Filter</string>
     <string name="everything_filtered_out">You have filtered out all event types</string>
     <string name="event_color">Event color</string>
     <string name="default_calendar_color">Default calendar color</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -29,7 +29,6 @@
     <string name="filter_events_by_type">Etkinlikleri türe göre filtrele</string>
     <string name="please_fill_location">Lütfen haritada gösterilecek bir yeri doldurun</string>
     <string name="public_event_notification_text">Bir etkinlik yaklaşıyor</string>
-    <string name="saving_filtered_out">Kaydediliyor… Ancak seçilen etkinlik türü üst Menü - Filtre kısmında filtreleniyor</string>
     <string name="everything_filtered_out">Tüm etkinlik türlerini filtrelediniz</string>
     <string name="event_color">Event color</string>
     <string name="default_calendar_color">Default calendar color</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -29,7 +29,6 @@
     <string name="filter_events_by_type">Фільтрувати події за типом</string>
     <string name="please_fill_location">Будь ласка, вкажіть місце, що буде показано на карті</string>
     <string name="public_event_notification_text">Наближається подія</string>
-    <string name="saving_filtered_out">Збереження… Але вибраний тип події відфільтровується у верхньому Меню - Фільтр</string>
     <string name="everything_filtered_out">Відфільтровано всі типи подій</string>
     <string name="event_color">Event color</string>
     <string name="default_calendar_color">Default calendar color</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -29,7 +29,6 @@
     <string name="filter_events_by_type">依类型筛选活动</string>
     <string name="please_fill_location">请填入要显示在地图上的地点</string>
     <string name="public_event_notification_text">一个活动即将到来</string>
-    <string name="saving_filtered_out">正在保存…但所选择的活动类型在顶部菜单的“筛选”中被过滤掉</string>
     <string name="everything_filtered_out">你过滤掉了所有活动类型</string>
     <string name="event_color">Event color</string>
     <string name="default_calendar_color">Default calendar color</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -29,7 +29,6 @@
     <string name="filter_events_by_type">依類型篩選活動</string>
     <string name="please_fill_location">請填入要顯示在地圖上的地點</string>
     <string name="public_event_notification_text">一個活動即將到來</string>
-    <string name="saving_filtered_out">Saving… But the selected event type is filtered out in the top Menu - Filter</string>
     <string name="everything_filtered_out">You have filtered out all event types</string>
     <string name="event_color">Event color</string>
     <string name="default_calendar_color">Default calendar color</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -29,7 +29,6 @@
     <string name="filter_events_by_type">依類型篩選活動</string>
     <string name="please_fill_location">請填入要顯示在地圖上的地點</string>
     <string name="public_event_notification_text">一個活動即將到來</string>
-    <string name="saving_filtered_out">Saving… But the selected event type is filtered out in the top Menu - Filter</string>
     <string name="everything_filtered_out">You have filtered out all event types</string>
     <string name="event_color">Event color</string>
     <string name="default_calendar_color">Default calendar color</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -31,7 +31,6 @@
     <string name="filter_events_by_type">Filter events by type</string>
     <string name="please_fill_location">Please fill in a location to be shown on a map</string>
     <string name="public_event_notification_text">An event is upcoming</string>
-    <string name="saving_filtered_out">Saving… But the selected event type is filtered out in the top Menu - Filter</string>
     <string name="everything_filtered_out">You have filtered out all event types</string>
     <string name="event_color">Event color</string>
     <string name="default_calendar_color">Default calendar color</string>


### PR DESCRIPTION
We are doing it in `insertEvent()`, `insertTask()` methods because it's cleaner than doing it in `EventActivity` and `TaskActivity`.

The event types stay disabled if the user adds new events using some other client, the event types are enabled only if the event is added using Simple Calendar.