### PR TITLE
add Exact alarm permission to fix issues on Android 13-14 targeting

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
     <uses-permission android:name="android.permission.WRITE_CALENDAR" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+    <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <uses-permission


### PR DESCRIPTION
 Add USE_EXACT_ALARM permission. Is new permission that is only to be used by [Calendar or alarm clock apps](https://support.google.com/googleplay/android-developer/answer/12253906#exact_alarm_preview)

[According to documentation](https://developer.android.com/about/versions/14/changes/schedule-exact-alarms): The USE_EXACT_ALARM permission will be granted on installation, and apps holding this permission will be able to schedule exact alarms just like apps with the [SCHEDULE_EXACT_ALARM](https://developer.android.com/reference/android/Manifest.permission#SCHEDULE_EXACT_ALARM) permission.