### PR TITLE
Added editing options for repeating events in weekly view (#2122)

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/activities/EventActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/activities/EventActivity.kt
@@ -1307,7 +1307,7 @@ class EventActivity : SimpleActivity() {
         // recreate the event if it was moved in a different CalDAV calendar
         if (mEvent.id != null && oldSource != newSource && oldSource != SOURCE_IMPORTED_ICS) {
             if (mRepeatInterval > 0 && wasRepeatable) {
-                applyOriginalStartEndTimes()
+                eventsHelper.applyOriginalStartEndTimes(mEvent, mOriginalStartTS, mOriginalEndTS)
             }
             eventsHelper.deleteEvent(mEvent.id!!, true)
             mEvent.id = null
@@ -1358,65 +1358,26 @@ class EventActivity : SimpleActivity() {
     private fun showEditRepeatingEventDialog() {
         EditRepeatingEventDialog(this) {
             hideKeyboard()
+            if (it == null) {
+                return@EditRepeatingEventDialog
+            }
             when (it) {
                 EDIT_SELECTED_OCCURRENCE -> {
-                    ensureBackgroundThread {
-                        mEvent.apply {
-                            parentId = id!!.toLong()
-                            id = null
-                            repeatRule = 0
-                            repeatInterval = 0
-                            repeatLimit = 0
-                        }
-
-                        eventsHelper.insertEvent(mEvent, addToCalDAV = true, showToasts = true) {
-                            finish()
-                        }
+                    eventsHelper.editSelectedOccurrence(mEvent, true) {
+                        finish()
                     }
                 }
                 EDIT_FUTURE_OCCURRENCES -> {
-                    ensureBackgroundThread {
-                        val eventId = mEvent.id!!
-                        val originalEvent = eventsDB.getEventWithId(eventId) ?: return@ensureBackgroundThread
-                        mEvent.maybeAdjustRepeatLimitCount(originalEvent, mEventOccurrenceTS)
-                        mEvent.id = null
-                        eventsHelper.apply {
-                            addEventRepeatLimit(eventId, mEventOccurrenceTS)
-                            if (mEventOccurrenceTS == originalEvent.startTS) {
-                                deleteEvent(eventId, true)
-                            }
-
-                            insertEvent(mEvent, addToCalDAV = true, showToasts = true) {
-                                finish()
-                            }
-                        }
+                    eventsHelper.editFutureOccurrences(mEvent, mEventOccurrenceTS, true) {
+                        finish()
                     }
                 }
                 EDIT_ALL_OCCURRENCES -> {
-                    ensureBackgroundThread {
-                        applyOriginalStartEndTimes()
-                        eventsHelper.updateEvent(mEvent, updateAtCalDAV = true, showToasts = true) {
-                            finish()
-                        }
+                    eventsHelper.editAllOccurrences(mEvent, mOriginalStartTS, mOriginalEndTS, true) {
+                        finish()
                     }
                 }
             }
-        }
-    }
-
-    private fun applyOriginalStartEndTimes() {
-        // Shift the start and end times of the first (original) event based on the changes made
-        val originalEvent = eventsDB.getEventWithId(mEvent.id!!) ?: return
-        val originalStartTS = originalEvent.startTS
-        val originalEndTS = originalEvent.endTS
-        val oldStartTS = mOriginalStartTS
-        val oldEndTS = mOriginalEndTS
-
-        mEvent.apply {
-            val startTSDelta = oldStartTS - startTS
-            val endTSDelta = oldEndTS - endTS
-            startTS = originalStartTS - startTSDelta
-            endTS = originalEndTS - endTSDelta
         }
     }
 

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/activities/TaskActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/activities/TaskActivity.kt
@@ -471,55 +471,23 @@ class TaskActivity : SimpleActivity() {
     private fun showEditRepeatingTaskDialog() {
         EditRepeatingEventDialog(this, isTask = true) {
             hideKeyboard()
+            if (it == null) {
+                return@EditRepeatingEventDialog
+            }
             when (it) {
                 EDIT_SELECTED_OCCURRENCE -> {
-                    ensureBackgroundThread {
-                        mTask.apply {
-                            parentId = id!!.toLong()
-                            id = null
-                            repeatRule = 0
-                            repeatInterval = 0
-                            repeatLimit = 0
-                        }
-
-                        eventsHelper.insertTask(mTask, showToasts = true) {
-                            finish()
-                        }
+                    eventsHelper.editSelectedOccurrence(mTask, true) {
+                        finish()
                     }
                 }
                 EDIT_FUTURE_OCCURRENCES -> {
-                    ensureBackgroundThread {
-                        val taskId = mTask.id!!
-                        val originalTask = eventsDB.getTaskWithId(taskId) ?: return@ensureBackgroundThread
-                        mTask.maybeAdjustRepeatLimitCount(originalTask, mTaskOccurrenceTS)
-                        mTask.id = null
-                        eventsHelper.apply {
-                            addEventRepeatLimit(taskId, mTaskOccurrenceTS)
-                            if (mTaskOccurrenceTS == originalTask.startTS) {
-                                deleteEvent(taskId, true)
-                            }
-
-                            insertTask(mTask, showToasts = true) {
-                                finish()
-                            }
-                        }
+                    eventsHelper.editFutureOccurrences(mTask, mTaskOccurrenceTS, true) {
+                        finish()
                     }
                 }
                 EDIT_ALL_OCCURRENCES -> {
-                    ensureBackgroundThread {
-                        // Shift the start and end times of the first (original) event based on the changes made
-                        val originalEvent = eventsDB.getTaskWithId(mTask.id!!) ?: return@ensureBackgroundThread
-                        val originalStartTS = originalEvent.startTS
-                        val oldStartTS = mOriginalStartTS
-
-                        mTask.apply {
-                            val startTSDelta = oldStartTS - startTS
-                            startTS = originalStartTS - startTSDelta
-                            endTS = startTS
-                        }
-                        eventsHelper.updateEvent(mTask, updateAtCalDAV = false, showToasts = true) {
-                            finish()
-                        }
+                    eventsHelper.editAllOccurrences(mTask, mOriginalStartTS, showToasts = true) {
+                        finish()
                     }
                 }
             }

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/dialogs/EditRepeatingEventDialog.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/dialogs/EditRepeatingEventDialog.kt
@@ -12,7 +12,7 @@ import com.simplemobiletools.commons.extensions.hideKeyboard
 import com.simplemobiletools.commons.extensions.setupDialogStuff
 import kotlinx.android.synthetic.main.dialog_edit_repeating_event.view.*
 
-class EditRepeatingEventDialog(val activity: SimpleActivity, val isTask: Boolean = false, val callback: (allOccurrences: Int) -> Unit) {
+class EditRepeatingEventDialog(val activity: SimpleActivity, val isTask: Boolean = false, val callback: (allOccurrences: Int?) -> Unit) {
     private var dialog: AlertDialog? = null
 
     init {
@@ -33,12 +33,15 @@ class EditRepeatingEventDialog(val activity: SimpleActivity, val isTask: Boolean
                 activity.setupDialogStuff(view, this) { alertDialog ->
                     dialog = alertDialog
                     alertDialog.hideKeyboard()
+                    alertDialog.setOnDismissListener { sendResult(null) }
                 }
             }
     }
 
-    private fun sendResult(allOccurrences: Int) {
+    private fun sendResult(allOccurrences: Int?) {
         callback(allOccurrences)
-        dialog?.dismiss()
+        if (allOccurrences != null) {
+            dialog?.dismiss()
+        }
     }
 }

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/fragments/WeekFragment.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/fragments/WeekFragment.kt
@@ -191,6 +191,7 @@ class WeekFragment : Fragment(), WeeklyCalendar {
 
     fun updateCalendar() {
         if (context != null) {
+            currentlyDraggedView = null
             WeeklyCalendarImpl(this, requireContext()).updateWeeklyCalendar(weekTimestamp)
         }
     }
@@ -299,9 +300,7 @@ class WeekFragment : Fragment(), WeeklyCalendar {
                                                     activity.hideKeyboard()
                                                     when (it) {
                                                         null -> {
-                                                            // force update by removing hash
-                                                            lastHash = 0
-                                                            updateCalendar()
+                                                            revertDraggedEvent()
                                                         }
                                                         EDIT_SELECTED_OCCURRENCE -> {
                                                             context?.eventsHelper?.editSelectedOccurrence(newEvent, false) {
@@ -323,8 +322,12 @@ class WeekFragment : Fragment(), WeeklyCalendar {
                                                 }
                                             }
                                         } else {
-                                            context?.eventsHelper?.updateEvent(newEvent, updateAtCalDAV = true, showToasts = false) {
-                                                updateCalendar()
+                                            if (event.startTS == newEvent.startTS && event.endTS == newEvent.endTS) {
+                                                revertDraggedEvent()
+                                            } else {
+                                                context?.eventsHelper?.updateEvent(newEvent, updateAtCalDAV = true, showToasts = false) {
+                                                    updateCalendar()
+                                                }
                                             }
                                         }
                                     }
@@ -338,6 +341,13 @@ class WeekFragment : Fragment(), WeeklyCalendar {
                     }
                 }
             }
+    }
+
+    private fun revertDraggedEvent() {
+        activity?.runOnUiThread {
+            currentlyDraggedView?.beVisible()
+            currentlyDraggedView = null
+        }
     }
 
     private fun getViewGestureDetector(view: ViewGroup, index: Int): GestureDetector {
@@ -932,7 +942,6 @@ class WeekFragment : Fragment(), WeeklyCalendar {
                     if (!dragEvent.result) {
                         view.beVisible()
                     }
-                    currentlyDraggedView = null
                     true
                 }
                 else -> false


### PR DESCRIPTION
Closes #2122

- Added `EditRepeatingEventDialog` to moving events and tasks in weekly view.
- Moved code for editing recurring events and tasks to `EventsHelper`to reuse it in `EventActivity`, `TaskActivity` and `WeekFragment`.
- Changed refreshing method in `WeekFragment` for case of editing all or future occurrences - `updateCalendar()` was refreshing only current fragment and there were another cached in `MainActivity` that still had old data, so in this case we have to refresh all fragments.
- These changes caused a small bug in weekly view - when user closed the `EditRepeatingEventDialog` without selecting anything, the event has disappeared. To fix this, I've added another case in `EditRepeatingEventDialog` to return `null` in callback, when the user hasn't selected anything. It doesn't affect `EventActivity` and `TaskActivity`.
  - ~~Also, to make this work, I had to force events' refreshing in `WeekFragment`. I'm doing this by resetting `lastHash` value.~~ EDIT: Instead of force refresh, I'm reverting dragged view. I've also added it to the case when event hasn't been changed, so it also fixes #2070

https://github.com/SimpleMobileTools/Simple-Calendar/assets/85929121/02c1b1c2-7d78-42f8-8eb1-aee5a774ef51

