### PR TITLE
Use local timezone to configure weekly views 

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/extensions/Context.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/extensions/Context.kt
@@ -758,6 +758,10 @@ fun Context.editEvent(event: ListEvent) {
 }
 
 fun Context.getFirstDayOfWeek(date: DateTime): String {
+    return getFirstDayOfWeekDt(date).toString()
+}
+
+fun Context.getFirstDayOfWeekDt(date: DateTime): DateTime {
     var startOfWeek = date.withTimeAtStartOfDay()
     if (!config.startWeekWithCurrentDay) {
         startOfWeek = if (config.isSundayFirst) {
@@ -771,7 +775,7 @@ fun Context.getFirstDayOfWeek(date: DateTime): String {
             startOfWeek.withDayOfWeek(DateTimeConstants.MONDAY)
         }
     }
-    return startOfWeek.toString()
+    return startOfWeek
 }
 
 fun Context.isTaskCompleted(event: Event): Boolean {

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/extensions/Context.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/extensions/Context.kt
@@ -20,7 +20,6 @@ import android.provider.CalendarContract
 import android.view.View
 import android.view.ViewGroup
 import android.widget.LinearLayout
-import android.widget.Toast
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.app.AlarmManagerCompat
 import androidx.core.app.NotificationCompat
@@ -48,7 +47,6 @@ import com.simplemobiletools.commons.helpers.*
 import kotlinx.android.synthetic.main.day_monthly_event_view.view.*
 import org.joda.time.DateTime
 import org.joda.time.DateTimeConstants
-import org.joda.time.DateTimeZone
 import org.joda.time.LocalDate
 import java.io.File
 import java.io.FileOutputStream
@@ -327,7 +325,8 @@ fun Context.notifyEvent(originalEvent: Event) {
         val events = eventsHelper.getRepeatableEventsFor(currentSeconds - WEEK_SECONDS, currentSeconds + YEAR_SECONDS, event.id!!)
         for (currEvent in events) {
             eventStartTS = if (currEvent.getIsAllDay()) Formatter.getDayStartTS(Formatter.getDayCodeFromTS(currEvent.startTS)) else currEvent.startTS
-            val firstReminderMinutes = arrayOf(currEvent.reminder3Minutes, currEvent.reminder2Minutes, currEvent.reminder1Minutes).filter { it != REMINDER_OFF }.max()
+            val firstReminderMinutes =
+                arrayOf(currEvent.reminder3Minutes, currEvent.reminder2Minutes, currEvent.reminder1Minutes).filter { it != REMINDER_OFF }.max()
             if (eventStartTS - firstReminderMinutes * 60 > currentSeconds) {
                 break
             }
@@ -759,7 +758,7 @@ fun Context.editEvent(event: ListEvent) {
 }
 
 fun Context.getFirstDayOfWeek(date: DateTime): String {
-    var startOfWeek = date.withZoneRetainFields(DateTimeZone.UTC).withTimeAtStartOfDay()
+    var startOfWeek = date.withTimeAtStartOfDay()
     if (!config.startWeekWithCurrentDay) {
         startOfWeek = if (config.isSundayFirst) {
             // a workaround for Joda-time's Monday-as-first-day-of-the-week

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/fragments/WeekFragment.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/fragments/WeekFragment.kt
@@ -196,14 +196,14 @@ class WeekFragment : Fragment(), WeeklyCalendar {
         mView.week_events_columns_holder.removeAllViews()
         (0 until config.weeklyViewDays).forEach {
             val column = inflater.inflate(R.layout.weekly_view_day_column, mView.week_events_columns_holder, false) as RelativeLayout
-            column.tag = Formatter.getUTCDayCodeFromTS(weekTimestamp + it * DAY_SECONDS)
+            column.tag = Formatter.getDayCodeFromTS(weekTimestamp + it * DAY_SECONDS)
             mView.week_events_columns_holder.addView(column)
             dayColumns.add(column)
         }
     }
 
     private fun setupDayLabels() {
-        var curDay = Formatter.getUTCDateTimeFromTS(weekTimestamp)
+        var curDay = Formatter.getDateTimeFromTS(weekTimestamp)
         val todayCode = Formatter.getDayCodeFromDateTime(DateTime())
         val screenWidth = context?.usableScreenSize?.x ?: return
         val dayWidth = screenWidth / config.weeklyViewDays

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/fragments/WeekFragmentsHolder.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/fragments/WeekFragmentsHolder.kt
@@ -311,7 +311,7 @@ class WeekFragmentsHolder : MyFragmentHolder(), WeekFragmentListener {
 
     override fun getCurrentDate(): DateTime? {
         return if (currentWeekTS != 0L) {
-            Formatter.getUTCDateTimeFromTS(currentWeekTS)
+            Formatter.getDateTimeFromTS(currentWeekTS)
         } else {
             null
         }

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/fragments/WeekFragmentsHolder.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/fragments/WeekFragmentsHolder.kt
@@ -189,22 +189,11 @@ class WeekFragmentsHolder : MyFragmentHolder(), WeekFragmentListener {
     }
 
     private fun dateSelected(dateTime: DateTime, datePicker: DatePicker) {
-        val isSundayFirst = requireContext().config.isSundayFirst
         val month = datePicker.month + 1
         val year = datePicker.year
         val day = datePicker.dayOfMonth
-        var newDateTime = dateTime.withDate(year, month, day)
-
-        if (isSundayFirst) {
-            newDateTime = newDateTime.plusDays(1)
-        }
-
-        var selectedWeek = newDateTime.withDayOfWeek(1).withTimeAtStartOfDay().minusDays(if (isSundayFirst) 1 else 0)
-        if (newDateTime.minusDays(7).seconds() > selectedWeek.seconds()) {
-            selectedWeek = selectedWeek.plusDays(7)
-        }
-
-        currentWeekTS = selectedWeek.seconds()
+        val newDateTime = dateTime.withDate(year, month, day)
+        currentWeekTS = requireContext().getFirstDayOfWeekDt(newDateTime).seconds()
         setupFragment()
     }
 


### PR DESCRIPTION
Closes https://github.com/SimpleMobileTools/Simple-Calendar/issues/2143

##### Why did this happen?
<details> 
<summary>
Click to expand

</summary>

1. The `MainActivity` retrieves the start-of-week in UTC using the `getFirstDayOfWeek()` method, resulting in a timestamp like `2023-07-16T00:00:00.000Z`.
2. The start-of-week timestamp is then passed to the `WeekFragmentsHolder` as an argument called `WEEK_START_DATE_TIME`.
3. In the `WeekFragmentsHolder`, the `WEEK_START_DATE_TIME` is parsed and stored as `currentWeekTS` in seconds. The `DateTime.parse()` method handles time zones during parsing.
4. The `getWeekTimestamps(currentWeekTS)` method is used to generate start-of-week timestamps for all prefilled weeks and is passed to the `MyWeekPagerAdapter`.
5. The UTC start-of-week timestamps are then passed down to the `WeekFragment` using the `WEEK_START_TIMESTAMP` argument.
6. In the `WeekFragment`, when creating a new event, the event start timestamp is calculated based on the start-of-week timestamp, and the `EventActivity` is launched with the `NEW_EVENT_START_TS` argument.
7. In the `EventActivity`, the `NEW_EVENT_START_TS` is treated as if it's in the local timezone, causing the created event to be shifted forward or backward by a day due to potential time zone differences.


</details>

##### Why not handle everything in UTC instead?

The weekly view originally used the local timezone to configure everything but was modified to use UTC only to fix a `Start week with Sunday` issue https://github.com/SimpleMobileTools/Simple-Calendar/issues/1213 where events were created on the wrong day. Since `getFirstDayOfWeek()` was rewritten to handle week preferences properly, there is no need to complicate things using UTC anymore (otherwise we'll have to handle UTC-to-local-timezone conversion in many cases).


This also fixes an issue with the drag-and-drop feature where the events were moved by ±1 day because the difference in timezone was not taken care of.

I have tested this with many time zones and made sure the related issues (#1894, #1281, #1213) don't pop back. I also carefully examined all usages of `getFirstDayOfWeek()` and did not find anything that could break by switching to local timezone.