### PR TITLE
Use proper day of month to calculate start index in week

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/fragments/YearFragment.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/fragments/YearFragment.kt
@@ -104,7 +104,8 @@ class YearFragment : Fragment(), YearlyCalendar {
             }
 
             monthHolder.monthLabel.setTextColor(curTextColor)
-            monthView.firstDay = requireContext().getProperDayIndexInWeek(dateTime.withMonthOfYear(monthOfYear))
+            val firstDayOfMonth = dateTime.withMonthOfYear(monthOfYear).withDayOfMonth(1)
+            monthView.firstDay = requireContext().getProperDayIndexInWeek(firstDayOfMonth)
             val numberOfDays = dateTime.withMonthOfYear(monthOfYear).dayOfMonth().maximumValue
             monthView.setDays(numberOfDays)
             monthView.setOnClickListener {


### PR DESCRIPTION
This PR fixes the issue where weeks start on the wrong day in the yearly view.

I was surprised to see this issue because I had tested it rigorously when implementing "Start week on any day", it turns out I broke it during view-binding migration.