### PR TITLE
Fix crash when deserializing attendee class

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,7 +6,6 @@ plugins {
     alias(libs.plugins.android)
     alias(libs.plugins.kotlinAndroid)
     alias(libs.plugins.ksp)
-    alias(libs.plugins.parcelize)
     base
 }
 

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/activities/EventActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/activities/EventActivity.kt
@@ -24,6 +24,8 @@ import android.widget.RelativeLayout
 import com.google.android.material.timepicker.MaterialTimePicker
 import com.google.android.material.timepicker.MaterialTimePicker.INPUT_MODE_CLOCK
 import com.google.android.material.timepicker.TimeFormat
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
 import com.simplemobiletools.calendar.pro.R
 import com.simplemobiletools.calendar.pro.adapters.AutoCompleteTextViewAdapter
 import com.simplemobiletools.calendar.pro.databinding.ActivityEventBinding
@@ -169,7 +171,7 @@ class EventActivity : SimpleActivity() {
             putInt(REPEAT_RULE, mRepeatRule)
             putLong(REPEAT_LIMIT, mRepeatLimit)
 
-            putParcelableArrayList(ATTENDEES, getAllAttendees(false))
+            putString(ATTENDEES, Gson().toJson(getAllAttendees(false)))
 
             putInt(AVAILABILITY, mAvailability)
             putInt(EVENT_COLOR, mEventColor)
@@ -211,7 +213,8 @@ class EventActivity : SimpleActivity() {
             mRepeatRule = getInt(REPEAT_RULE)
             mRepeatLimit = getLong(REPEAT_LIMIT)
 
-            mAttendees = getParcelableArrayList(ATTENDEES) ?: arrayListOf()
+            val token = object : TypeToken<List<Attendee>>() {}.type
+            mAttendees = Gson().fromJson<ArrayList<Attendee>>(getString(ATTENDEES), token) ?: ArrayList()
 
             mEventTypeId = getLong(EVENT_TYPE_ID)
             mEventCalendarId = getInt(EVENT_CALENDAR_ID)

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/models/Attendee.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/models/Attendee.kt
@@ -2,16 +2,13 @@ package com.simplemobiletools.calendar.pro.models
 
 import android.content.Context
 import android.graphics.drawable.Drawable
-import android.os.Parcelable
 import android.provider.CalendarContract
 import android.widget.ImageView
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.engine.DiskCacheStrategy
 import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions
 import com.bumptech.glide.request.RequestOptions
-import kotlinx.parcelize.Parcelize
 
-@Parcelize
 data class Attendee(
     val contactId: Int,
     var name: String,
@@ -20,7 +17,7 @@ data class Attendee(
     var photoUri: String,
     var isMe: Boolean,
     var relationship: Int
-) : Parcelable {
+) {
     fun getPublicName() = name.ifEmpty { email }
 
     fun updateImage(context: Context, imageView: ImageView, placeholder: Drawable) {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,6 @@ plugins {
     alias(libs.plugins.android).apply(false)
     alias(libs.plugins.kotlinAndroid).apply(false)
     alias(libs.plugins.ksp).apply(false)
-    alias(libs.plugins.parcelize).apply(false)
 }
 
 tasks.register<Delete>("clean") {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,5 +45,4 @@ room = [
 android = { id = "com.android.application", version.ref = "gradlePlugins-agp" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 kotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
 


### PR DESCRIPTION
It crashes only in release mode, it won't crash if you just enable minify in debug mode.

When the `Attendee` class is serialized using Gson, the resulting JSON still uses the obfuscated member names (a, b, c etc...) because proper proguard rules for Gson aren't added. Thus we can not make changes to the `Attendee` data class without affecting it's obfuscated Json member names. 