### PR TITLE
Fix for: Clicking on a day in the monthly view and selecting the wrong day #2235

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/views/AutoGridLayoutManager.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/views/AutoGridLayoutManager.kt
@@ -25,7 +25,7 @@ class AutoGridLayoutManager(
             val totalSpace = if (orientation == VERTICAL) {
                 width - paddingRight - paddingLeft
             } else {
-                height - paddingTop - paddingBottom
+                height - paddingTop*20 - paddingBottom
             }
             spanCount = max(1, totalSpace / itemWidth)
         }

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/views/AutoGridLayoutManager.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/views/AutoGridLayoutManager.kt
@@ -25,7 +25,7 @@ class AutoGridLayoutManager(
             val totalSpace = if (orientation == VERTICAL) {
                 width - paddingRight - paddingLeft
             } else {
-                height - paddingTop*20 - paddingBottom
+                height - paddingTop - paddingBottom
             }
             spanCount = max(1, totalSpace / itemWidth)
         }

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/views/MonthView.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/views/MonthView.kt
@@ -276,7 +276,7 @@ class MonthView(context: Context, attrs: AttributeSet, defStyle: Int) : View(con
             verticalOffset = max(verticalOffset, dayVerticalOffsets[event.startDayIndex + i])
         }
         val xPos = event.startDayIndex % 7 * dayWidth + horizontalOffset
-        val yPos = (event.startDayIndex / 7) * dayHeight
+        val yPos = (event.startDayIndex / 10) * dayHeight
         val xPosCenter = xPos + dayWidth / 2
 
         if (verticalOffset - eventTitleHeight * 2 > dayHeight) {

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/views/MonthViewWrapper.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/views/MonthViewWrapper.kt
@@ -69,7 +69,7 @@ class MonthViewWrapper(context: Context, attrs: AttributeSet, defStyle: Int) : F
             val childLeft = x * dayWidth + horizontalOffset - child.translationX
             val childTop = y * dayHeight + weekDaysLetterHeight - child.translationY
             val childWidth = child.measuredWidth
-            val childHeight = child.measuredHeight
+            val childHeight = child.measuredHeight/2
             val childRight = childLeft + childWidth
             val childBottom = childTop + childHeight
 
@@ -108,9 +108,14 @@ class MonthViewWrapper(context: Context, attrs: AttributeSet, defStyle: Int) : F
     }
 
     private fun measureSizes() {
-        dayWidth = (width ) / 7f
-        dayHeight = (height - weekDaysLetterHeight) / 6f
+        // Supposons que vous avez 7 colonnes et 6 lignes
+        val columns = 7
+        val rows = 6
+
+        dayWidth = ((width - horizontalOffset) / columns).toFloat()
+        dayHeight = ((height - weekDaysLetterHeight) / rows).toFloat()
     }
+
 
     private fun addClickableBackgrounds() {
         removeAllViews()
@@ -129,39 +134,42 @@ class MonthViewWrapper(context: Context, attrs: AttributeSet, defStyle: Int) : F
     }
 
     private fun addViewBackground(viewX: Int, viewY: Int, day: DayMonthly) {
-        val xPos = viewX * dayWidth + horizontalOffset
-        val yPos = viewY * dayHeight*10 + weekDaysLetterHeight
+        // Utilisez dayWidth et dayHeight pour définir la taille visuelle totale du jour
+        val totalDayWidth = dayWidth
+        val totalDayHeight = dayHeight
 
-        MonthViewBackgroundBinding.inflate(inflater, this, false).root.apply {
-            if (isMonthDayView) {
-                background = null
-            }
+        // Définissez la zone cliquable à un pourcentage de la taille totale du jour
+        val clickableWidth = (totalDayWidth * 0.7).toInt()  // 70% de la largeur totale
+        val clickableHeight = (totalDayHeight * 0.7).toInt() // 70% de la hauteur totale
 
-            // Supposons que vous vouliez que la zone cliquable soit 80% de la largeur et de la hauteur du jour
-            val clickableWidth = (dayWidth * 0.8).toInt()
-            val clickableHeight = (dayHeight * 0.8).toInt()
+        // Calculez les positions x et y pour centrer la zone cliquable dans la cellule du jour
+        val xPos = viewX * totalDayWidth + (totalDayWidth - clickableWidth) / 2 + horizontalOffset
+        val yPos = viewY * totalDayHeight + (totalDayHeight - clickableHeight) / 2 + weekDaysLetterHeight
 
-            layoutParams = FrameLayout.LayoutParams(clickableWidth, clickableHeight).apply {
-                leftMargin = (xPos + ((dayWidth - clickableWidth) / 2).toInt()).toInt()
-                topMargin = (yPos + ((dayHeight - clickableHeight) /2 ).toInt()).toInt()
+        // Créez les paramètres de disposition pour la vue cliquable
+        val clickableLayoutParams = FrameLayout.LayoutParams(clickableWidth, clickableHeight)
+        clickableLayoutParams.setMargins(xPos.toInt(), yPos.toInt(), 0, 0)
+
+        val dayView = MonthViewBackgroundBinding.inflate(inflater, this, false).root.apply {
+            this.layoutParams = clickableLayoutParams
+            if (BuildConfig.DEBUG) {
+                setBackgroundResource(R.drawable.debug_day_border) // Appliquez la bordure rouge si en mode débogage
             }
 
             setOnClickListener {
+                // Gérez le clic sur la zone cliquable ici
                 dayClickCallback?.invoke(day)
-
                 if (isMonthDayView) {
                     binding.monthView.updateCurrentlySelectedDay(viewX, viewY)
                 }
             }
-
-            // Set the debug background if in debug mode
-            if (BuildConfig.DEBUG) {
-                this.setBackgroundResource(R.drawable.debug_day_border)
-            }
-
-            addView(this)
         }
+
+        addView(dayView)  // Ajoutez la vue cliquable à la hiérarchie de la vue parente
     }
+
+
+
 
 
 

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/views/MonthViewWrapper.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/views/MonthViewWrapper.kt
@@ -134,19 +134,19 @@ class MonthViewWrapper(context: Context, attrs: AttributeSet, defStyle: Int) : F
     }
 
     private fun addViewBackground(viewX: Int, viewY: Int, day: DayMonthly) {
-        // Utilisez dayWidth et dayHeight pour définir la taille visuelle totale du jour
+        // utilisation de dayWidth et dayHeight pour définir la taille visuelle totale du jour
         val totalDayWidth = dayWidth
         val totalDayHeight = dayHeight
 
-        // Définissez la zone cliquable à un pourcentage de la taille totale du jour
+        // la zone cliquable à un pourcentage de la taille totale du jour
         val clickableWidth = (totalDayWidth * 0.7).toInt()  // 70% de la largeur totale
         val clickableHeight = (totalDayHeight * 0.7).toInt() // 70% de la hauteur totale
 
-        // Calculez les positions x et y pour centrer la zone cliquable dans la cellule du jour
+        // Calcule les positions x et y pour centrer la zone cliquable dans la cellule du jour
         val xPos = viewX * totalDayWidth + (totalDayWidth - clickableWidth) / 2 + horizontalOffset
         val yPos = viewY * totalDayHeight + (totalDayHeight - clickableHeight) / 2 + weekDaysLetterHeight
 
-        // Créez les paramètres de disposition pour la vue cliquable
+        // Création des paramètres de disposition pour la vue cliquable
         val clickableLayoutParams = FrameLayout.LayoutParams(clickableWidth, clickableHeight)
         clickableLayoutParams.setMargins(xPos.toInt(), yPos.toInt(), 0, 0)
 
@@ -157,7 +157,7 @@ class MonthViewWrapper(context: Context, attrs: AttributeSet, defStyle: Int) : F
             }
 
             setOnClickListener {
-                // Gérez le clic sur la zone cliquable ici
+                // gestion de clic sur la zone cliquable
                 dayClickCallback?.invoke(day)
                 if (isMonthDayView) {
                     binding.monthView.updateCurrentlySelectedDay(viewX, viewY)
@@ -165,7 +165,7 @@ class MonthViewWrapper(context: Context, attrs: AttributeSet, defStyle: Int) : F
             }
         }
 
-        addView(dayView)  // Ajoutez la vue cliquable à la hiérarchie de la vue parente
+        addView(dayView)  // ajout de la vue cliquable à la hiérarchie de la vue parente
     }
 
 

--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/views/MonthViewWrapper.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/views/MonthViewWrapper.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.widget.FrameLayout
+import com.simplemobiletools.calendar.pro.BuildConfig
+import com.simplemobiletools.calendar.pro.R
 import com.simplemobiletools.calendar.pro.databinding.MonthViewBackgroundBinding
 import com.simplemobiletools.calendar.pro.databinding.MonthViewBinding
 import com.simplemobiletools.calendar.pro.extensions.config
@@ -106,7 +108,7 @@ class MonthViewWrapper(context: Context, attrs: AttributeSet, defStyle: Int) : F
     }
 
     private fun measureSizes() {
-        dayWidth = (width - horizontalOffset) / 7f
+        dayWidth = (width ) / 7f
         dayHeight = (height - weekDaysLetterHeight) / 6f
     }
 
@@ -119,7 +121,7 @@ class MonthViewWrapper(context: Context, attrs: AttributeSet, defStyle: Int) : F
             for (x in 0 until COLUMN_COUNT) {
                 val day = days.getOrNull(curId)
                 if (day != null) {
-                    addViewBackground(x, y, day)
+                    addViewBackground(x, y/2, day)
                 }
                 curId++
             }
@@ -128,17 +130,22 @@ class MonthViewWrapper(context: Context, attrs: AttributeSet, defStyle: Int) : F
 
     private fun addViewBackground(viewX: Int, viewY: Int, day: DayMonthly) {
         val xPos = viewX * dayWidth + horizontalOffset
-        val yPos = viewY * dayHeight + weekDaysLetterHeight
+        val yPos = viewY * dayHeight*10 + weekDaysLetterHeight
 
         MonthViewBackgroundBinding.inflate(inflater, this, false).root.apply {
             if (isMonthDayView) {
                 background = null
             }
 
-            layoutParams.width = dayWidth.toInt()
-            layoutParams.height = dayHeight.toInt()
-            x = xPos
-            y = yPos
+            // Supposons que vous vouliez que la zone cliquable soit 80% de la largeur et de la hauteur du jour
+            val clickableWidth = (dayWidth * 0.8).toInt()
+            val clickableHeight = (dayHeight * 0.8).toInt()
+
+            layoutParams = FrameLayout.LayoutParams(clickableWidth, clickableHeight).apply {
+                leftMargin = (xPos + ((dayWidth - clickableWidth) / 2).toInt()).toInt()
+                topMargin = (yPos + ((dayHeight - clickableHeight) /2 ).toInt()).toInt()
+            }
+
             setOnClickListener {
                 dayClickCallback?.invoke(day)
 
@@ -147,9 +154,17 @@ class MonthViewWrapper(context: Context, attrs: AttributeSet, defStyle: Int) : F
                 }
             }
 
+            // Set the debug background if in debug mode
+            if (BuildConfig.DEBUG) {
+                this.setBackgroundResource(R.drawable.debug_day_border)
+            }
+
             addView(this)
         }
     }
+
+
+
 
     fun togglePrintMode() {
         binding.monthView.togglePrintMode()

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="app_name">Agenda simple</string>
     <string name="app_launcher_name">Agenda</string>
     <string name="change_view">Changer de vue</string>
@@ -159,7 +159,7 @@
     <string name="add_holidays">Ajouter des jours fériés</string>
     <string name="national_holidays">Jours fériés nationaux</string>
     <string name="religious_holidays">Jours fériés religieux</string>
-    <string name="holidays_imported_successfully">Les jours fériés ont été correctement importés dans le type d'évènement \'Jours fériés\'</string>
+    <string name="holidays_imported_successfully">Les jours fériés ont été correctement importés dans le type d\'évènement \'Jours fériés\'</string>
     <string name="importing_some_holidays_failed">L\'importation de certains évènements a échoué</string>
     <string name="importing_holidays_failed">L\'importation des jours fériés a échoué</string>
     <!-- Settings -->
@@ -252,17 +252,17 @@
     <string name="today_only">Aujourd\'hui seulement</string>
     <string name="within_the_next">Au cours du prochain…</string>
     <plurals name="within_the_next_days">
-        <item quantity="one">Au cours de la prochaine journée</item>
+        <item quantity="one" tools:ignore="ImpliedQuantity">Au cours de la prochaine journée</item>
         <item quantity="many">Au cours des %d prochains jours</item>
         <item quantity="other">Au cours des %d prochains jours</item>
     </plurals>
     <plurals name="within_the_next_weeks">
-        <item quantity="one">Au cours de la prochaine semaine</item>
+        <item quantity="one" tools:ignore="ImpliedQuantity">Au cours de la prochaine semaine</item>
         <item quantity="many">Au cours des %d prochaines semaines</item>
         <item quantity="other">Au cours des %d prochaines semaines</item>
     </plurals>
     <plurals name="within_the_next_months">
-        <item quantity="one">Au cours du prochain mois</item>
+        <item quantity="one" tools:ignore="ImpliedQuantity">Au cours du prochain mois</item>
         <item quantity="many">Au cours des %d prochains mois</item>
         <item quantity="other">Au cours des %d prochains mois</item>
     </plurals>


### PR DESCRIPTION
By altering the childHeight value to be half of the child view's measured height in our onLayout method, we've halved the size of the clickable areas in our calendar. This change has impacted how child views are arranged, particularly the layout() method that positions and sizes views within their container. Consequently, only clicks in the lower half of the calendar cells are recognized, even though the cells look visually unchanged. 


All that's left to do is remove the red grid that helped us understand the problem.

[
![ZONECLIQUABLE](https://github.com/SimpleMobileTools/Simple-Calendar/assets/69893942/3ac34f0f-87fc-40e8-b537-a2c229f00683)
](url)