### PR TITLE
[L10n] Update MainActivity.kt: "ราชอาณาจักรไทย" -> "ไทย"

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/calendar/pro/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calendar/pro/activities/MainActivity.kt
@@ -1319,7 +1319,7 @@ class MainActivity : SimpleActivity(), RefreshRecyclerViewListener {
             put("Suomi", "finland.ics")
             put("Sverige", "sweden.ics")
             put("Taiwan", "taiwan.ics")
-            put("ราชอาณาจักรไทย", "thailand.ics")
+            put("ไทย", "thailand.ics")
             put("Türkiye Cumhuriyeti", "turkey.ics")
             put("Ukraine", "ukraine.ics")
             put("United Kingdom", "unitedkingdom.ics")


### PR DESCRIPTION
Use a normal form of the country name, not the official. Same as in latest CLDR. http://unicode.org/Public/cldr/44/